### PR TITLE
symlinks do have a size

### DIFF
--- a/fuseprivate.c
+++ b/fuseprivate.c
@@ -47,6 +47,8 @@ sqfs_err sqfs_stat(sqfs *fs, sqfs_inode *inode, struct stat *st) {
 	} else if (S_ISBLK(st->st_mode) || S_ISCHR(st->st_mode)) {
 		st->st_rdev = sqfs_makedev(inode->xtra.dev.major,
 			inode->xtra.dev.minor);
+	} else if (S_ISLNK(st->st_mode)) {
+		st->st_size = inode->xtra.symlink_size;
 	}
 	
 	st->st_blksize = fs->sb.block_size; /* seriously? */


### PR DESCRIPTION
size of a symlink in "stat" structure should be the link target string size