### PR TITLE
Improve performance by enabling vfs cache

### DIFF
--- a/hl.c
+++ b/hl.c
@@ -161,6 +161,7 @@ static int sqfs_hl_op_open(const char *path, struct fuse_file_info *fi) {
 	}
 	
 	fi->fh = (intptr_t)inode;
+	fi->keep_cache = 1;
 	return 0;
 }
 

--- a/ll.c
+++ b/ll.c
@@ -203,6 +203,7 @@ static void sqfs_ll_op_open(fuse_req_t req, fuse_ino_t ino,
 		fuse_reply_err(req, EISDIR);
 	} else {
 		fi->fh = (intptr_t)inode;
+		fi->keep_cache = 1;
 		fuse_reply_open(req, fi);
 		return;
 	}


### PR DESCRIPTION
Avoids repeated decompression, allowing the kernel's vfs cache to function for pages already decompressed.