### PR TITLE
Add squashfuse_extract tool

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -62,8 +62,10 @@ squashfuse_ls_SOURCES = ls.c
 squashfuse_ls_LDADD = libsquashfuse.la $(COMPRESSION_LIBS)
 # Sample program squashfuse_extract
 noinst_PROGRAMS += squashfuse_extract
+squashfuse_extract_CPPFLAGS = $(FUSE_CPPFLAGS)
 squashfuse_extract_SOURCES = extract.c
-squashfuse_extract_LDADD = libsquashfuse.la $(COMPRESSION_LIBS)
+squashfuse_extract_LDADD = libsquashfuse.la libfuseprivate.la $(COMPRESSION_LIBS) \
+  $(FUSE_LIBS)
 endif
 
 # Handle generation of swap include files

--- a/Makefile.am
+++ b/Makefile.am
@@ -60,6 +60,10 @@ if SQ_WANT_DEMO
 noinst_PROGRAMS += squashfuse_ls
 squashfuse_ls_SOURCES = ls.c
 squashfuse_ls_LDADD = libsquashfuse.la $(COMPRESSION_LIBS)
+# Sample program squashfuse_extract
+noinst_PROGRAMS += squashfuse_extract
+squashfuse_extract_SOURCES = extract.c
+squashfuse_extract_LDADD = libsquashfuse.la $(COMPRESSION_LIBS)
 endif
 
 # Handle generation of swap include files

--- a/README
+++ b/README
@@ -109,6 +109,16 @@ detailed instructions:
    But if you'd rather install it, run `make install'. If you need root
    privileges, `sudo make install' may work.
 
+For example on Ubuntu 16.04:
+
+sudo apt-get -y install git autoconf libtool make gcc libtool libfuse-dev liblzma-dev
+libtoolize --force
+aclocal
+autoheader
+automake --force-missing --add-missing
+autoconf
+./configure --with-xz=/usr/lib/
+make
 
 2d. Usage
 ---------

--- a/README
+++ b/README
@@ -109,6 +109,9 @@ detailed instructions:
    But if you'd rather install it, run `make install'. If you need root
    privileges, `sudo make install' may work.
 
+2e. Example: Ubuntu
+-------------------
+
 For example on Ubuntu 16.04:
 
 sudo apt-get -y install git autoconf libtool make gcc libtool libfuse-dev liblzma-dev
@@ -120,7 +123,8 @@ autoconf
 ./configure --with-xz=/usr/lib/
 make
 
-2d. Usage
+
+2e. Usage
 ---------
 You'll need a SquashFS archive to use squashfuse. If you don't already have
 one, you can create one using the `mksquashfs' utility from the squashfs-tools

--- a/README
+++ b/README
@@ -109,6 +109,7 @@ detailed instructions:
    But if you'd rather install it, run `make install'. If you need root
    privileges, `sudo make install' may work.
 
+
 2e. Example: Ubuntu
 -------------------
 

--- a/README
+++ b/README
@@ -110,7 +110,7 @@ detailed instructions:
    privileges, `sudo make install' may work.
 
 
-2e. Example: Ubuntu
+2d. Example: Ubuntu
 -------------------
 
 For example on Ubuntu 16.04:

--- a/extract.c
+++ b/extract.c
@@ -1,0 +1,64 @@
+#include "squashfuse.h"
+
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define PROGNAME "squashfuse_extract"
+
+#define ERR_MISC	(-1)
+#define ERR_USAGE	(-2)
+#define ERR_OPEN	(-3)
+
+static void usage() {
+	fprintf(stderr, "Usage: %s ARCHIVE PATH_TO_EXTRACT\n", PROGNAME);
+	exit(ERR_USAGE);
+}
+
+static void die(const char *msg) {
+	fprintf(stderr, "%s\n", msg);
+	exit(ERR_MISC);
+}
+
+int main(int argc, char *argv[]) {
+	sqfs_err err = SQFS_OK;
+	sqfs_traverse trv;
+	sqfs fs;
+	char *image;
+    	char *path_to_extract;
+
+	if (argc != 3)
+		usage();
+	image = argv[1];
+	path_to_extract = argv[2];
+
+	if ((err = sqfs_open_image(&fs, image, 0)))
+		exit(ERR_OPEN);
+	
+	if ((err = sqfs_traverse_open(&trv, &fs, sqfs_inode_root(&fs))))
+		die("sqfs_traverse_open error");
+	while (sqfs_traverse_next(&trv, &err)) {
+		if (!trv.dir_end) {
+            if(strcmp(trv.path, path_to_extract) == 0){
+                fprintf(stderr, "Extracting %s\n", trv.path);
+                fprintf(stderr, "sqfs_inode_id: %lu\n", trv.entry.inode);
+                sqfs_inode inode;
+                if (sqfs_inode_get(&fs, &inode, trv.entry.inode))
+                    die("sqfs_inode_get error");
+                fprintf(stderr, "file_size: %lu\n", inode.xtra.reg.file_size);
+                char *buf = malloc(inode.xtra.reg.file_size);
+                if (sqfs_read_range(&fs, &inode, 0, &inode.xtra.reg.file_size, buf))
+                    die("sqfs_read_range error");
+		printf("%s", buf);
+		free(buf);
+            	}
+	    }
+	}
+	if (err)
+		die("sqfs_traverse_next error");
+	sqfs_traverse_close(&trv);
+	
+	sqfs_fd_close(fs.fd);
+	return 0;
+}

--- a/extract.c
+++ b/extract.c
@@ -12,34 +12,34 @@
 #define ERR_OPEN	(-3)
 
 static void usage() {
-	fprintf(stderr, "Usage: %s ARCHIVE PATH_TO_EXTRACT\n", PROGNAME);
-	exit(ERR_USAGE);
+    fprintf(stderr, "Usage: %s ARCHIVE PATH_TO_EXTRACT\n", PROGNAME);
+    exit(ERR_USAGE);
 }
 
 static void die(const char *msg) {
-	fprintf(stderr, "%s\n", msg);
-	exit(ERR_MISC);
+    fprintf(stderr, "%s\n", msg);
+    exit(ERR_MISC);
 }
 
 int main(int argc, char *argv[]) {
-	sqfs_err err = SQFS_OK;
-	sqfs_traverse trv;
-	sqfs fs;
-	char *image;
-    	char *path_to_extract;
-
-	if (argc != 3)
-		usage();
-	image = argv[1];
-	path_to_extract = argv[2];
-
-	if ((err = sqfs_open_image(&fs, image, 0)))
-		exit(ERR_OPEN);
-	
-	if ((err = sqfs_traverse_open(&trv, &fs, sqfs_inode_root(&fs))))
-		die("sqfs_traverse_open error");
-	while (sqfs_traverse_next(&trv, &err)) {
-		if (!trv.dir_end) {
+    sqfs_err err = SQFS_OK;
+    sqfs_traverse trv;
+    sqfs fs;
+    char *image;
+    char *path_to_extract;
+    
+    if (argc != 3)
+        usage();
+    image = argv[1];
+    path_to_extract = argv[2];
+    
+    if ((err = sqfs_open_image(&fs, image, 0)))
+        exit(ERR_OPEN);
+    
+    if ((err = sqfs_traverse_open(&trv, &fs, sqfs_inode_root(&fs))))
+        die("sqfs_traverse_open error");
+    while (sqfs_traverse_next(&trv, &err)) {
+        if (!trv.dir_end) {
             if(strcmp(trv.path, path_to_extract) == 0){
                 fprintf(stderr, "Extracting %s\n", trv.path);
                 fprintf(stderr, "sqfs_inode_id: %lu\n", trv.entry.inode);
@@ -50,15 +50,15 @@ int main(int argc, char *argv[]) {
                 char *buf = malloc(inode.xtra.reg.file_size);
                 if (sqfs_read_range(&fs, &inode, 0, &inode.xtra.reg.file_size, buf))
                     die("sqfs_read_range error");
-		printf("%s", buf);
-		free(buf);
-            	}
-	    }
-	}
-	if (err)
-		die("sqfs_traverse_next error");
-	sqfs_traverse_close(&trv);
-	
-	sqfs_fd_close(fs.fd);
-	return 0;
+                fwrite (buf, 1, inode.xtra.reg.file_size, stdout);
+                free(buf);
+            }
+        }
+    }
+    if (err)
+        die("sqfs_traverse_next error");
+    sqfs_traverse_close(&trv);
+    
+    sqfs_fd_close(fs.fd);
+    return 0;
 }

--- a/extract.c
+++ b/extract.c
@@ -137,7 +137,7 @@ int main(int argc, char *argv[]) {
         
                     // Read the file in chunks
                     off_t bytes_already_read = 0;
-                    size_t bytes_at_a_time = 1024; 
+                    size_t bytes_at_a_time = 64*1024; 
                     FILE * f;
                     f = fopen (prefixed_path_to_extract, "w+");
                     if (f == NULL)
@@ -155,7 +155,7 @@ int main(int argc, char *argv[]) {
                     fclose(f);
                     chmod (prefixed_path_to_extract, st.st_mode);
                 } else if (inode.base.inode_type == SQUASHFS_SYMLINK_TYPE){
-                    size_t size = 1024;
+                    size_t size = strlen(trv.path)+1;
                     char *buf = malloc(size);
                     sqfs_readlink(&fs, &inode, buf, &size);
                     fprintf(stderr, "Symlink: %s to %s \n", prefixed_path_to_extract, buf);

--- a/extract.c
+++ b/extract.c
@@ -90,7 +90,15 @@ int main(int argc, char *argv[]) {
                     }
                     fclose(f);
                 } else if(inode.base.inode_type == SQUASHFS_SYMLINK_TYPE){
-                    fprintf(stderr, "TODO: Implement symlink: ./%s\n", trv.path);
+                    size_t size = 1024;
+                    char *buf = malloc(size);
+                    sqfs_readlink(&fs, &inode, buf, &size);
+                    // fwrite(buf, 1, size, stdout);
+                    fprintf(stderr, "Symlink: %s to %s \n", trv.path, buf );
+                    int ret = symlink(buf, trv.path);
+                    if (ret != 0)
+                        die("symlink error");
+                    free(buf);
                 } else {
                     fprintf(stderr, "TODO: Implement inode.base.inode_type %i\n", inode.base.inode_type);
                 }

--- a/extract.c
+++ b/extract.c
@@ -80,7 +80,7 @@ int main(int argc, char *argv[]) {
     
     prefix = "squashfs-root/";
     
-    if(access(prefix, F_OK ) == -1 ) {
+    if (access(prefix, F_OK ) == -1 ) {
         if (mkdir(prefix, 0777) == -1) {
             perror("mkdir error");
             exit(EXIT_FAILURE);
@@ -99,7 +99,7 @@ int main(int argc, char *argv[]) {
         die("sqfs_traverse_open error");
     while (sqfs_traverse_next(&trv, &err)) {
         if (!trv.dir_end) {
-            if((startsWith(path_to_extract, trv.path) != 0) || (strcmp("-a", path_to_extract) == 0)){
+            if ((startsWith(path_to_extract, trv.path) != 0) || (strcmp("-a", path_to_extract) == 0)){
                 fprintf(stderr, "trv.path: %s\n", trv.path);
                 fprintf(stderr, "sqfs_inode_id: %lu\n", trv.entry.inode);
                 sqfs_inode inode;
@@ -109,18 +109,18 @@ int main(int argc, char *argv[]) {
                 fprintf(stderr, "inode.xtra.reg.file_size: %lu\n", inode.xtra.reg.file_size);
                 strcpy(prefixed_path_to_extract, "");
                 strcat(strcat(prefixed_path_to_extract, prefix), trv.path);
-                if(inode.base.inode_type == SQUASHFS_DIR_TYPE){
+                if (inode.base.inode_type == SQUASHFS_DIR_TYPE){
                     fprintf(stderr, "inode.xtra.dir.parent_inode: %ui\n", inode.xtra.dir.parent_inode);
                     fprintf(stderr, "mkdir: %s/\n", prefixed_path_to_extract);
-                    if(access(prefixed_path_to_extract, F_OK ) == -1 ) {
+                    if (access(prefixed_path_to_extract, F_OK ) == -1 ) {
                         if (mkdir(prefixed_path_to_extract, 0777) == -1) {
                             perror("mkdir error");
                             exit(1);
                         }
                     }
-                } else if(inode.base.inode_type == SQUASHFS_REG_TYPE){
+                } else if (inode.base.inode_type == SQUASHFS_REG_TYPE){
                     fprintf(stderr, "Extract to: %s\n", prefixed_path_to_extract);
-                    if(sqfs_stat(&fs, &inode, &st) != 0)
+                    if (sqfs_stat(&fs, &inode, &st) != 0)
                         die("sqfs_stat error");
                     printf("Permissions: ");
                     printf( (S_ISDIR(st.st_mode)) ? "d" : "-");
@@ -154,7 +154,7 @@ int main(int argc, char *argv[]) {
                     }
                     fclose(f);
                     chmod (prefixed_path_to_extract, st.st_mode);
-                } else if(inode.base.inode_type == SQUASHFS_SYMLINK_TYPE){
+                } else if (inode.base.inode_type == SQUASHFS_SYMLINK_TYPE){
                     size_t size = 1024;
                     char *buf = malloc(size);
                     sqfs_readlink(&fs, &inode, buf, &size);

--- a/extract.c
+++ b/extract.c
@@ -155,14 +155,13 @@ int main(int argc, char *argv[]) {
                     chmod (prefixed_path_to_extract, st.st_mode);
                 } else if (inode.base.inode_type == SQUASHFS_SYMLINK_TYPE){
                     size_t size = strlen(trv.path)+1;
-                    char *buf = malloc(size);
+                    char buf[size];
                     sqfs_readlink(&fs, &inode, buf, &size);
                     fprintf(stderr, "Symlink: %s to %s \n", prefixed_path_to_extract, buf);
                     unlink(prefixed_path_to_extract);
                     int ret = symlink(buf, prefixed_path_to_extract);
                     if (ret != 0)
                         die("symlink error");
-                    free(buf);
                 } else {
                     fprintf(stderr, "TODO: Implement inode.base.inode_type %i\n", inode.base.inode_type);
                 }

--- a/extract.c
+++ b/extract.c
@@ -16,7 +16,7 @@
 
 static void usage() {
     fprintf(stderr, "Usage: %s ARCHIVE PATH_TO_EXTRACT\n", PROGNAME);
-    fprintf(stderr, "       %s -a\n", PROGNAME);
+    fprintf(stderr, "       %s ARCHIVE -a\n", PROGNAME);
     exit(ERR_USAGE);
 }
 

--- a/extract.c
+++ b/extract.c
@@ -144,12 +144,11 @@ int main(int argc, char *argv[]) {
                         die("fopen error");
                     while (bytes_already_read < inode.xtra.reg.file_size)
                     {
-                        char *buf = malloc(bytes_at_a_time);
+                        char buf[bytes_at_a_time];
                         if (sqfs_read_range(&fs, &inode, (sqfs_off_t) bytes_already_read, &bytes_at_a_time, buf))
                             die("sqfs_read_range error");
                         // fwrite(buf, 1, bytes_at_a_time, stdout);
-                        fwrite(buf, 1, bytes_at_a_time, f);
-                        free(buf);                    
+                        fwrite(buf, 1, bytes_at_a_time, f);                 
                         bytes_already_read = bytes_already_read + bytes_at_a_time;
                     }
                     fclose(f);

--- a/extract.c
+++ b/extract.c
@@ -1,5 +1,4 @@
 #include "squashfuse.h"
-#include "fuseprivate.h"
 
 #include <fcntl.h>
 #include <stdio.h>
@@ -27,12 +26,46 @@ static void die(const char *msg) {
     exit(ERR_MISC);
 }
 
-
 bool startsWith(const char *pre, const char *str)
 {
     size_t lenpre = strlen(pre),
     lenstr = strlen(str);
     return lenstr < lenpre ? false : strncmp(pre, str, lenpre) == 0;
+}
+
+/* Fill in a stat structure. Does not set st_ino */
+sqfs_err sqfs_stat(sqfs *fs, sqfs_inode *inode, struct stat *st) {
+	sqfs_err err = SQFS_OK;
+	uid_t id;
+	
+	memset(st, 0, sizeof(*st));
+	st->st_mode = inode->base.mode;
+	st->st_nlink = inode->nlink;
+	st->st_mtime = st->st_ctime = st->st_atime = inode->base.mtime;
+	
+	if (S_ISREG(st->st_mode)) {
+		/* FIXME: do symlinks, dirs, etc have a size? */
+		st->st_size = inode->xtra.reg.file_size;
+		st->st_blocks = st->st_size / 512;
+	} else if (S_ISBLK(st->st_mode) || S_ISCHR(st->st_mode)) {
+		st->st_rdev = sqfs_makedev(inode->xtra.dev.major,
+			inode->xtra.dev.minor);
+	} else if (S_ISLNK(st->st_mode)) {
+		st->st_size = inode->xtra.symlink_size;
+	}
+	
+	st->st_blksize = fs->sb.block_size; /* seriously? */
+	
+	err = sqfs_id_get(fs, inode->base.uid, &id);
+	if (err)
+		return err;
+	st->st_uid = id;
+	err = sqfs_id_get(fs, inode->base.guid, &id);
+	st->st_gid = id;
+	if (err)
+		return err;
+	
+	return SQFS_OK;
 }
 
 int main(int argc, char *argv[]) {

--- a/extract.c
+++ b/extract.c
@@ -11,9 +11,9 @@
 
 #define PROGNAME "squashfuse_extract"
 
-#define ERR_MISC	(-1)
-#define ERR_USAGE	(-2)
-#define ERR_OPEN	(-3)
+#define ERR_MISC	(1)
+#define ERR_USAGE	(2)
+#define ERR_OPEN	(3)
 
 static void usage() {
     fprintf(stderr, "Usage: %s ARCHIVE PATH_TO_EXTRACT\n", PROGNAME);

--- a/extract.c
+++ b/extract.c
@@ -156,10 +156,12 @@ int main(int argc, char *argv[]) {
                 } else if (inode.base.inode_type == SQUASHFS_SYMLINK_TYPE){
                     size_t size = strlen(trv.path)+1;
                     char buf[size];
-                    sqfs_readlink(&fs, &inode, buf, &size);
+                    int ret = sqfs_readlink(&fs, &inode, buf, &size);
+                    if (ret != 0)
+                        die("sqfs_readlink error");
                     fprintf(stderr, "Symlink: %s to %s \n", prefixed_path_to_extract, buf);
                     unlink(prefixed_path_to_extract);
-                    int ret = symlink(buf, prefixed_path_to_extract);
+                    ret = symlink(buf, prefixed_path_to_extract);
                     if (ret != 0)
                         die("symlink error");
                 } else {

--- a/extract.c
+++ b/extract.c
@@ -76,6 +76,8 @@ int main(int argc, char *argv[]) {
                     size_t bytes_at_a_time = 1024; 
                     FILE * f;
                     f = fopen (trv.path, "w+");
+                    if (f == NULL)
+                        die("fopen error");
                     while (bytes_already_read < inode.xtra.reg.file_size)
                     {
                         char *buf = malloc(bytes_at_a_time);

--- a/extract.c
+++ b/extract.c
@@ -47,11 +47,18 @@ int main(int argc, char *argv[]) {
                 if (sqfs_inode_get(&fs, &inode, trv.entry.inode))
                     die("sqfs_inode_get error");
                 fprintf(stderr, "file_size: %lu\n", inode.xtra.reg.file_size);
-                char *buf = malloc(inode.xtra.reg.file_size);
-                if (sqfs_read_range(&fs, &inode, 0, &inode.xtra.reg.file_size, buf))
-                    die("sqfs_read_range error");
-                fwrite (buf, 1, inode.xtra.reg.file_size, stdout);
-                free(buf);
+                // Read the file in chunks
+                off_t bytes_already_read = 0;
+                size_t bytes_at_a_time = 1024;                
+                while ( bytes_already_read < inode.xtra.reg.file_size )
+                {
+                    char *buf = malloc(bytes_at_a_time);
+                    if (sqfs_read_range(&fs, &inode, bytes_already_read, &bytes_at_a_time, buf))
+                        die("sqfs_read_range error");
+                    fwrite (buf, 1, bytes_at_a_time, stdout);
+                    free(buf);                    
+                    bytes_already_read = bytes_already_read + bytes_at_a_time;
+                }
             }
         }
     }

--- a/extract.c
+++ b/extract.c
@@ -58,10 +58,10 @@ int main(int argc, char *argv[]) {
                 sqfs_inode inode;
                 if (sqfs_inode_get(&fs, &inode, trv.entry.inode))
                     die("sqfs_inode_get error");
-                fprintf(stderr, "inode.base.inode_type: %lu\n", inode.base.inode_type);
+                fprintf(stderr, "inode.base.inode_type: %i\n", inode.base.inode_type);
                 fprintf(stderr, "inode.xtra.reg.file_size: %lu\n", inode.xtra.reg.file_size);
                 if(inode.base.inode_type == SQUASHFS_DIR_TYPE){
-                    fprintf(stderr, "inode.xtra.dir.parent_inode: %lu\n", inode.xtra.dir.parent_inode);
+                    fprintf(stderr, "inode.xtra.dir.parent_inode: %ui\n", inode.xtra.dir.parent_inode);
                     fprintf(stderr, "mkdir: %s/\n", trv.path);
                     if(access(trv.path, F_OK ) == -1 ) {
                         if (mkdir(trv.path, 0777) == -1) {
@@ -81,7 +81,7 @@ int main(int argc, char *argv[]) {
                     while (bytes_already_read < inode.xtra.reg.file_size)
                     {
                         char *buf = malloc(bytes_at_a_time);
-                        if (sqfs_read_range(&fs, &inode, bytes_already_read, &bytes_at_a_time, buf))
+                        if (sqfs_read_range(&fs, &inode, (sqfs_off_t) bytes_already_read, &bytes_at_a_time, buf))
                             die("sqfs_read_range error");
                         // fwrite(buf, 1, bytes_at_a_time, stdout);
                         fwrite(buf, 1, bytes_at_a_time, f);
@@ -93,8 +93,8 @@ int main(int argc, char *argv[]) {
                     size_t size = 1024;
                     char *buf = malloc(size);
                     sqfs_readlink(&fs, &inode, buf, &size);
-                    // fwrite(buf, 1, size, stdout);
-                    fprintf(stderr, "Symlink: %s to %s \n", trv.path, buf );
+                    fprintf(stderr, "Symlink: %s to %s \n", trv.path, buf);
+                    unlink(trv.path);
                     int ret = symlink(buf, trv.path);
                     if (ret != 0)
                         die("symlink error");
@@ -102,7 +102,6 @@ int main(int argc, char *argv[]) {
                 } else {
                     fprintf(stderr, "TODO: Implement inode.base.inode_type %i\n", inode.base.inode_type);
                 }
-                
                 fprintf(stderr, "\n");
             }
         }
@@ -110,7 +109,6 @@ int main(int argc, char *argv[]) {
     if (err)
         die("sqfs_traverse_next error");
     sqfs_traverse_close(&trv);
-    
     sqfs_fd_close(fs.fd);
     return 0;
 }


### PR DESCRIPTION
The squashfuse_extract can extract files, directories, and symlinks from a squashfs image. Closes #13 and partly #9.