### PR TITLE
add -ouid=UID and -ogid=GID to override the uid and gid of squashfs.

### DIFF
--- a/fs.c
+++ b/fs.c
@@ -53,12 +53,14 @@ sqfs_compression_type sqfs_compression(sqfs *fs) {
 	return fs->sb.compression;
 }
 
-sqfs_err sqfs_init(sqfs *fs, sqfs_fd_t fd, size_t offset) {
+sqfs_err sqfs_init(sqfs *fs, sqfs_fd_t fd, size_t offset, int uid, int gid) {
 	sqfs_err err = SQFS_OK;
 	memset(fs, 0, sizeof(*fs));
 	
 	fs->fd = fd;
 	fs->offset = offset;
+	fs->uid = uid;
+	fs->gid = gid;
 	if (sqfs_pread(fd, &fs->sb, sizeof(fs->sb), fs->offset) != sizeof(fs->sb))
 		return SQFS_BADFORMAT;
 	sqfs_swapin_super_block(&fs->sb);

--- a/fs.h
+++ b/fs.h
@@ -36,6 +36,8 @@
 struct sqfs {
 	sqfs_fd_t fd;
 	size_t offset;
+        int uid;
+        int gid;
 	struct squashfs_super_block sb;
 	sqfs_table id_table;
 	sqfs_table frag_table;
@@ -86,7 +88,7 @@ void sqfs_version_supported(int *min_major, int *min_minor, int *max_major,
 size_t sqfs_divceil(uint64_t total, size_t group);
 
 
-sqfs_err sqfs_init(sqfs *fs, sqfs_fd_t fd, size_t offset);
+sqfs_err sqfs_init(sqfs *fs, sqfs_fd_t fd, size_t offset, int uid, int gid);
 void sqfs_destroy(sqfs *fs);
 
 /* Ok to call these even on incompletely constructed filesystems */

--- a/fuseprivate.h
+++ b/fuseprivate.h
@@ -48,8 +48,14 @@ typedef struct {
 	const char *image;
 	int mountpoint;
 	size_t offset;
+	int uid;
+	int gid;
+	const char *uid_str;
+	const char *gid_str;
 } sqfs_opts;
 int sqfs_opt_proc(void *data, const char *arg, int key,
 	struct fuse_args *outargs);
+
+sqfs_err sqfs_get_ids(sqfs_opts *opts);
 
 #endif

--- a/util.c
+++ b/util.c
@@ -67,14 +67,14 @@
 
 /* TODO: WIN32 implementation of open/close */
 /* TODO: i18n of error messages */
-sqfs_err sqfs_open_image(sqfs *fs, const char *image, size_t offset) {
+sqfs_err sqfs_open_image(sqfs *fs, const char *image, size_t offset, int uid, int gid) {
 	sqfs_err err;
 	sqfs_fd_t fd;
 
 	if ((err = sqfs_fd_open(image, &fd, stderr)))
 		return err;
 
-	err = sqfs_init(fs, fd, offset);
+	err = sqfs_init(fs, fd, offset, uid, gid);
 	switch (err) {
 		case SQFS_OK:
 			break;

--- a/util.h
+++ b/util.h
@@ -36,6 +36,6 @@ sqfs_err sqfs_fd_open(const char *path, sqfs_fd_t *fd, bool print);
 void sqfs_fd_close(sqfs_fd_t fd);
 
 /* Open a filesystem and print errors to stderr. */
-sqfs_err sqfs_open_image(sqfs *fs, const char *image, size_t offset);
+sqfs_err sqfs_open_image(sqfs *fs, const char *image, size_t offset, int uid, int gid);
 
 #endif


### PR DESCRIPTION
UID and GID can be numeric or textual.