### PR TITLE
Fix scan format for offset option

### DIFF
--- a/hl.c
+++ b/hl.c
@@ -271,7 +271,7 @@ int main(int argc, char *argv[]) {
 	int ret;
 	
 	struct fuse_opt fuse_opts[] = {
-		{"offset=%u", offsetof(sqfs_opts, offset), 0},
+		{"offset=%zu", offsetof(sqfs_opts, offset), 0},
 		FUSE_OPT_END
 	};
 

--- a/ll.c
+++ b/ll.c
@@ -400,7 +400,7 @@ int main(int argc, char *argv[]) {
 	int err;
 	sqfs_ll *ll;
 	struct fuse_opt fuse_opts[] = {
-		{"offset=%u", offsetof(sqfs_opts, offset), 0},
+		{"offset=%zu", offsetof(sqfs_opts, offset), 0},
 		FUSE_OPT_END
 	};
 	


### PR DESCRIPTION
The offset field in sqfs_opts has type size_t, so the scanf string needs to be %zu instead of %u, or the field length might mismatch.

Note that %zu is C99; an alternate solution would be to keep %u and change the type of the field to "unsigned" instead.  (Or use "%lu" and make the field "unsigned long".)