### PR TITLE
Add zstd compression support

### DIFF
--- a/CONFIGURATION
+++ b/CONFIGURATION
@@ -14,5 +14,6 @@ These are the most useful options to ./configure:
   --with-xz=PREFIX
   --with-lzo=PREFIX
   --with-lz4=PREFIX
+  --with-zstd=PREFIX
   
 More options are available in `./configure --help'

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-COMPRESSION_LIBS = $(ZLIB_LIBS) $(XZ_LIBS) $(LZO_LIBS) $(LZ4_LIBS)
+COMPRESSION_LIBS = $(ZLIB_LIBS) $(XZ_LIBS) $(LZO_LIBS) $(LZ4_LIBS) $(ZSTD_LIBS)
 
 ACLOCAL_AMFLAGS = -I m4 --install
 
@@ -23,7 +23,7 @@ libsquashfuse_la_SOURCES = swap.c cache.c table.c dir.c file.c fs.c \
 	dir.h file.h decompress.h xattr.h squashfuse.h hash.h stack.h traverse.h \
 	util.h fs.h
 libsquashfuse_la_CPPFLAGS = $(ZLIB_CPPFLAGS) $(XZ_CPPFLAGS) $(LZO_CPPFLAGS) \
-	$(LZ4_CPPFLAGS)
+	$(LZ4_CPPFLAGS) $(ZSTD_CPPFLAGS)
 libsquashfuse_la_LIBADD =
 
 # Helper for FUSE clients: libfuseprivate

--- a/configure.ac
+++ b/configure.ac
@@ -31,6 +31,7 @@ SQ_CHECK_DECOMPRESS([ZLIB],[z],[uncompress],[zlib.h])
 SQ_CHECK_DECOMPRESS([XZ],[lzma],[lzma_stream_buffer_decode],[lzma.h],[liblzma])
 SQ_CHECK_DECOMPRESS([LZO],[lzo2],[lzo1x_decompress_safe],[lzo/lzo1x.h])
 SQ_CHECK_DECOMPRESS([LZ4],[lz4],[LZ4_decompress_safe],[lz4.h])
+SQ_CHECK_DECOMPRESS([ZSTD],[zstd],[ZSTD_decompress],[zstd.h])
 AS_IF([test "x$sq_decompressors" = x],
 	[AC_MSG_FAILURE([At least one decompression library must exist])])
 

--- a/squashfs_fs.h
+++ b/squashfs_fs.h
@@ -126,6 +126,7 @@
 #define LZO_COMPRESSION		3
 #define XZ_COMPRESSION		4
 #define LZ4_COMPRESSION		5
+#define ZSTD_COMPRESSION	6
 
 struct squashfs_super_block {
 	__le32			s_magic;


### PR DESCRIPTION
* Zstd support has been added to SquashFS in the kernel in commit https://github.com/torvalds/linux/commit/87bf54bb43ddd385d2538b777324bf737f243042.
* Support is ready for `mksquashfs` and is coming to squashfs-tools soon https://sourceforge.net/p/squashfs/mailman/message/35996905/.