### PR TITLE
Introduce to squashfuse.pc.in

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -16,6 +16,9 @@ noinst_PROGRAMS =
 lib_LTLIBRARIES = libsquashfuse.la libfuseprivate.la
 include_HEADERS = squashfuse.h squashfs_fs.h
 
+pkgconfigdir = @pkgconfigdir@
+pkgconfig_DATA 	= squashfuse.pc
+
 # Main library: libsquashfuse
 libsquashfuse_la_SOURCES = swap.c cache.c table.c dir.c file.c fs.c \
 	decompress.c xattr.c hash.c stack.c traverse.c util.c \

--- a/configure.ac
+++ b/configure.ac
@@ -8,6 +8,9 @@ AM_SILENT_RULES(yes)
 AM_PROG_AR
 LT_INIT
 
+PKG_PROG_PKG_CONFIG
+PKG_INSTALLDIR
+
 # Compiler
 AC_PROG_AWK
 AC_PROG_SED
@@ -62,7 +65,7 @@ AS_IF([test "x$enable_high_level$enable_low_level$enable_demo" = xnonono],
 	AC_MSG_FAILURE([Nothing left to build]))
 
 
-AC_CONFIG_FILES([Makefile])
+AC_CONFIG_FILES([Makefile squashfuse.pc])
 AC_OUTPUT
 
 AS_ECHO()

--- a/squashfuse.pc.in
+++ b/squashfuse.pc.in
@@ -1,0 +1,12 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: squashfuse
+Description: squashfuse library to mount squashfs archives
+Version: @VERSION@
+
+Requires:
+Libs: -L${libdir} -lsquashfuse
+Cflags: -I${includedir}


### PR DESCRIPTION
I leave squashfuse.pc.in's Requires empty since i want to do short and easy to review PR. It won't break anything for the moment, and i'm continuing on the packaging of squashfuse for nixos distribution.