### PR TITLE
Add support for an idle timeout when mounting a squashfile.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 squashfuse
 squashfuse_ll
 squashfuse_ls
+squashfuse_extract
 *.dSYM
 *.o
 *.lo

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([squashfuse], [0.1.101], [dave@vasilevsky.ca])
+AC_INIT([squashfuse], [0.1.102], [dave@vasilevsky.ca])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_HEADERS([config.h])

--- a/fuseprivate.h
+++ b/fuseprivate.h
@@ -48,6 +48,7 @@ typedef struct {
 	const char *image;
 	int mountpoint;
 	size_t offset;
+	unsigned int idle_timeout_secs;
 } sqfs_opts;
 int sqfs_opt_proc(void *data, const char *arg, int key,
 	struct fuse_args *outargs);

--- a/ll.c
+++ b/ll.c
@@ -47,7 +47,7 @@ static unsigned int idle_timeout_secs = 0;
 static time_t last_access = 0;
 /* count of files and directories currently open.  drecement after
  * last_access for correctness. */
-static unsigned int open_refcount = 0;
+static sig_atomic_t open_refcount = 0;
 /* same as lib/fuse_signals.c */
 static struct fuse_session *fuse_instance = NULL;
 


### PR DESCRIPTION
If specified via the timeout option (-o timeout=N), then squashfuse_ll
will track the time of all accesses as well as the count of open files
and directories.  If the open count is zero and more seconds than the
specified timeout have passed since the last activity on the
filesystem, then we exit.

The approach is based on fuse's own signal handling (from
lib/fuse_signals.c).