### PR TITLE
Fix segfault when failures to read occur

### DIFF
--- a/cache.c
+++ b/cache.c
@@ -80,6 +80,21 @@ void *sqfs_cache_add(sqfs_cache *cache, sqfs_cache_idx idx) {
 	return sqfs_cache_entry(cache, i);
 }
 
+/* sqfs_cache_add can be called but the caller can fail to fill it (IO
+ * error, etc).  sqfs_cache_invalidate invalidates the cache entry.
+ * It does not call dispose; it merely marks the entry as reusable
+ * since it is never fully initialized.
+ */
+void sqfs_cache_invalidate(sqfs_cache *cache, sqfs_cache_idx idx) {
+	size_t i;
+	for (i = 0; i < cache->count; ++i) {
+		if (cache->idxs[i] == idx) {
+			cache->idxs[i] = SQFS_CACHE_IDX_INVALID;
+			return;
+		}
+	}
+}
+
 static void sqfs_block_cache_dispose(void *data) {
 	sqfs_block_cache_entry *entry = (sqfs_block_cache_entry*)data;
 	sqfs_block_dispose(entry->block);

--- a/cache.h
+++ b/cache.h
@@ -54,6 +54,7 @@ void sqfs_cache_destroy(sqfs_cache *cache);
 
 void *sqfs_cache_get(sqfs_cache *cache, sqfs_cache_idx idx);
 void *sqfs_cache_add(sqfs_cache *cache, sqfs_cache_idx idx);
+void sqfs_cache_invalidate(sqfs_cache *cache, sqfs_cache_idx idx);
 
 
 typedef struct {

--- a/fs.c
+++ b/fs.c
@@ -196,8 +196,10 @@ sqfs_err sqfs_md_cache(sqfs *fs, sqfs_off_t *pos, sqfs_block **block) {
 		/* fprintf(stderr, "MD BLOCK: %12llx\n", (long long)*pos); */
 		err = sqfs_md_block_read(fs, *pos,
 			&entry->data_size, &entry->block);
-		if (err)
+		if (err) {
+			sqfs_cache_invalidate(&fs->md_cache, *pos);
 			return err;
+		}
 	}
 	*block = entry->block;
 	*pos += entry->data_size;
@@ -212,8 +214,10 @@ sqfs_err sqfs_data_cache(sqfs *fs, sqfs_cache *cache, sqfs_off_t pos,
 		entry = sqfs_cache_add(cache, pos);
 		err = sqfs_data_block_read(fs, pos, hdr,
 			&entry->block);
-		if (err)
+		if (err) {
+			sqfs_cache_invalidate(cache, pos);
 			return err;
+		}
 	}
 	*block = entry->block;
 	return SQFS_OK;


### PR DESCRIPTION
The root issue is sqfs_cache_add always reserved an allocated space
before a read failure occurred.  When the failure then happened, the
entry was still "alive" and later would be discarded, causing
segfaults.

Now when these failures occur, we mark the entry as invalid.  Since
"in-place construction" didn't complete, we don't call discard.

This crash was reproducible by simply adding a `return SQFS_ERR;` in
`sqfs_data_block_read`.  Before this fix, the process would crash (and
ASAN would verify this); with this fix, the process stays up and the
caller receives an `Input/output error` instead.