### PR TITLE
extract: Silence warnings

### DIFF
--- a/extract.c
+++ b/extract.c
@@ -6,6 +6,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <sys/stat.h>
+#include "nonstd.h"
 #include "squashfs_fs.h"
 
 
@@ -101,12 +102,12 @@ int main(int argc, char *argv[]) {
         if (!trv.dir_end) {
             if ((startsWith(path_to_extract, trv.path) != 0) || (strcmp("-a", path_to_extract) == 0)){
                 fprintf(stderr, "trv.path: %s\n", trv.path);
-                fprintf(stderr, "sqfs_inode_id: %lu\n", trv.entry.inode);
+                fprintf(stderr, "sqfs_inode_id: %llu\n", (unsigned long long)trv.entry.inode);
                 sqfs_inode inode;
                 if (sqfs_inode_get(&fs, &inode, trv.entry.inode))
                     die("sqfs_inode_get error");
                 fprintf(stderr, "inode.base.inode_type: %i\n", inode.base.inode_type);
-                fprintf(stderr, "inode.xtra.reg.file_size: %lu\n", inode.xtra.reg.file_size);
+                fprintf(stderr, "inode.xtra.reg.file_size: %llu\n", (unsigned long long)inode.xtra.reg.file_size);
                 strcpy(prefixed_path_to_extract, "");
                 strcat(strcat(prefixed_path_to_extract, prefix), trv.path);
                 if (inode.base.inode_type == SQUASHFS_DIR_TYPE){


### PR DESCRIPTION
* Include `nonstd.h` for `sqfs_makedev()` definition.
* Fix conversion warnings on OS X in `fprintf()`.

Tested the build on OS X and Centos 7 with clang and gcc and there were no
warnings.