### PR TITLE
Move headers to subdir of include/, install missing headers

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -14,7 +14,11 @@ bin_PROGRAMS =
 noinst_PROGRAMS =
 
 lib_LTLIBRARIES = libsquashfuse.la libfuseprivate.la
-include_HEADERS = squashfuse.h squashfs_fs.h
+
+pkgincludedir = @includedir@/squashfuse
+pkginclude_HEADERS = squashfuse.h squashfs_fs.h \
+	cache.h common.h config.h decompress.h dir.h file.h fs.h stack.h table.h \
+	traverse.h util.h xattr.h
 
 pkgconfigdir = @pkgconfigdir@
 pkgconfig_DATA 	= squashfuse.pc

--- a/squashfuse.pc.in
+++ b/squashfuse.pc.in
@@ -1,7 +1,7 @@
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
-includedir=@includedir@
+includedir=@includedir@/squashfuse
 
 Name: squashfuse
 Description: squashfuse library to mount squashfs archives


### PR DESCRIPTION
The install process currently installs only `squashfuse.h` and `squashfs_fs.h`, directly into `PREFIX/include/`.

Unfortunately, because the contents of `squashfuse.h` is only:
https://github.com/vasi/squashfuse/blob/0b48352ed7a89d920bb6792ac59f9f6775088f02/squashfuse.h#L28-L33

it is useless without those other files, and the installation is broken (cannot be compiled against).

This PR adds all of the listed headers, plus any `#include`d by _those_ headers, to the `pkgconfigdir_HEADERS` list, and sets `pkgconfigdir = @includedir@/squashfuse`. This means that all of the necessary headers will be installed in `PREFIX/include/squashfuse/` and they can be referenced at that path to build software that links against the library.

The `squashfuse.pc.in` file is also updated to point `includedir` to the new subdirectory. (There may be a more clever way of writing the `.pc.in` file that makes use of `@pkgconfigdir@` directly, but I couldn't find a way to make that work. It just kept passing through the template processing unreplaced.)