### PR TITLE
Add Cirrus-CI config for FreeBSD CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,12 @@
+env:
+  CIRRUS_CLONE_DEPTH: 1
+
+freebsd_12_task:
+  freebsd_instance:
+    image: freebsd-12-1-release-amd64
+  install_script:
+    - pkg install -y autoconf automake fusefs-libs libtool pkgconf
+  build_script:
+    - sh autogen.sh
+    - ./configure
+    - make


### PR DESCRIPTION
This currently only builds, because it appears the tests do not yet run
on FreeBSD (issue #41).