### PR TITLE
Add CI support to ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,11 @@ jobs:
     env: CHECK_FEATURES=all
   - name: Windows
     os: windows
+  - name: PowerPC
+    os: linux
+    arch: ppc64le
+    dist: bionic
+    env: CHECK_FEATURES=all  
 env:
   global:
     - MAKEFLAGS="-j3"


### PR DESCRIPTION
Adding support to linux on power little endian architecture. squashfuse is part of ubuntu distribution on this architecture as well and continuously building/testing on this arch will ensure we detect/fix any issues early and are always up-to-date.