### PR TITLE
Use optimized linux byteswap macros if available.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -82,6 +82,9 @@ endif
 TESTS =
 if SQ_FUSE_TESTS
 TESTS += tests/ll-smoke.sh
+check_PROGRAMS = endiantest
+endiantest_SOURCES = tests/endiantest.c
+TESTS += endiantest
 endif
 if SQ_DEMO_TESTS
 TESTS += tests/ls.sh

--- a/configure.ac
+++ b/configure.ac
@@ -58,6 +58,9 @@ AC_CHECK_TYPE([__le16],[
 	AC_DEFINE([HAVE_LINUX_TYPES_LE16],1,
 		[Define if <linux/types.h> defines the type __le16])
 ],,[#include <linux/types.h>])
+AC_CHECK_HEADERS([asm/byteorder.h])
+AC_CHECK_HEADERS([endian.h machine/endian.h], [break])
+AC_C_INLINE
 
 
 # Other options

--- a/swap.c
+++ b/swap.c
@@ -24,6 +24,7 @@
  */
 #include "swap.h"
 
+#ifndef HAVE_ASM_BYTEORDER_H
 #define SWAP(BITS) \
 	void sqfs_swapin##BITS(uint##BITS##_t *v) { \
 		int i; \
@@ -40,10 +41,7 @@ SWAP(16)
 SWAP(32)
 SWAP(64)
 #undef SWAP
-
-void sqfs_swapin16_internal(__le16 *v) { sqfs_swapin16((uint16_t*)v); }
-void sqfs_swapin32_internal(__le32 *v) { sqfs_swapin32((uint32_t*)v); }
-void sqfs_swapin64_internal(__le64 *v) { sqfs_swapin64((uint64_t*)v); }
+#endif
 
 void sqfs_swap16(uint16_t *n) {
 	*n = (*n >> 8) + (*n << 8);

--- a/swap.h
+++ b/swap.h
@@ -26,16 +26,41 @@
 #define SQFS_SWAP_H
 
 #include "common.h"
+#include "squashfs_fs.h"
+#ifdef HAVE_ASM_BYTEORDER_H
+#include <asm/byteorder.h>
+#endif
 
 #define SQFS_MAGIC_SWAP 0x68737173
 
 void sqfs_swap16(uint16_t *n);
 
+#ifdef HAVE_ASM_BYTEORDER_H
+static inline void sqfs_swapin16(uint16_t *v) {
+    *v = __le16_to_cpu(*v);
+}
+static inline void sqfs_swapin32(uint32_t *v) {
+    *v = __le32_to_cpu(*v);
+}
+static inline void sqfs_swapin64(uint64_t *v) {
+    *v = __le64_to_cpu(*v);
+}
+#else
 void sqfs_swapin16(uint16_t *v);
 void sqfs_swapin32(uint32_t *v);
 void sqfs_swapin64(uint64_t *v);
+#endif
 
-#include "squashfs_fs.h"
+static inline void sqfs_swapin16_internal(__le16 *v) {
+	sqfs_swapin16((uint16_t*)v);
+}
+static inline void sqfs_swapin32_internal(__le32 *v) {
+	sqfs_swapin32((uint32_t*)v);
+}
+static inline void sqfs_swapin64_internal(__le64 *v) {
+	sqfs_swapin64((uint64_t*)v);
+}
+
 #include "swap.h.inc"
 
 #endif

--- a/tests/endiantest.c
+++ b/tests/endiantest.c
@@ -1,0 +1,45 @@
+/* Compare results of our macros vs. functions provided by
+ * endian.h, if available. If not available, simply skip
+ * tests.
+ */
+#if defined(HAVE_ENDIAN_H)
+#define _DEFAULT_SOURCE
+#include <endian.h>
+#elif defined(HAVE_MACHINE_ENDIAN_H)
+#include <machine/endian.h>
+#else
+#define SKIP_ENDIAN_TESTS
+#endif
+
+#ifndef SKIP_ENDIAN_TESTS
+#include "swap.h"
+
+int test16(void) {
+	uint16_t val = htole16(0xbabe);
+	sqfs_swapin16(&val);
+	return val == 0xbabe;
+}
+
+int test32(void) {
+	uint32_t val = htole32(0xc0ffee01);
+	sqfs_swapin32(&val);
+	return val == 0xc0ffee01;
+}
+
+int test64(void) {
+	uint64_t val = htole64(0xf00ddeadbeeff00dUL);
+	sqfs_swapin64(&val);
+	return val == 0xf00ddeadbeeff00dUL;
+}
+
+int main(void) {
+	return test16() && test32() && test64() ? 0 : 1;
+}
+
+#else /* SKIP_ENDIAN_TESTS */
+
+int main(void) {
+	return 0;
+}
+
+#endif


### PR DESCRIPTION
Updated from original pull request to get rid of google test dependency - test cases are so simple there is no need for a test framework at all, just simple binary that returns non-zero on failure.