### PR TITLE
Split squashfuse_ll into a lib and executable

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -17,7 +17,7 @@ task:
   build_script:
     - ./autogen.sh
     - CPPFLAGS="$CONFIGURE_CPPFLAGS -Werror" LDFLAGS="$CONFIGURE_LDFLAGS" ./configure
-    - make
+    - make V=1
   test_script:
     - make check
     - diff -u ci/expected-features/all ci/features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           ./autogen.sh
           CPPFLAGS="-Werror" ./configure
-          make -j3
+          make -j3 V=1
       - name: test
         run: |
           make check

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ build-aux
 configure
 libtool
 stamp-h1
-squashfuse.pc
+*.pc
 
 win/Debug
 win/Release

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ jobs:
     os: windows
 env:
   global:
-    - MAKEFLAGS="-j3"
+    - MAKEFLAGS="-j3 V=1"
 addons:
   apt:
     update: true

--- a/Makefile.am
+++ b/Makefile.am
@@ -57,12 +57,20 @@ endif
 
 # Low-level squashfuse_ll, if supported
 if SQ_WANT_LOWLEVEL
-bin_PROGRAMS += squashfuse_ll
-squashfuse_ll_SOURCES = ll.c ll_inode.c nonstd-daemon.c ll.h
-squashfuse_ll_CPPFLAGS = $(FUSE_CPPFLAGS)
-squashfuse_ll_LDADD = libsquashfuse.la libfuseprivate.la $(COMPRESSION_LIBS) \
+lib_LTLIBRARIES += libsquashfuse_ll.la
+libsquashfuse_ll_la_SOURCES = ll.c ll_inode.c nonstd-daemon.c
+libsquashfuse_ll_la_CPPFLAGS = $(FUSE_CPPFLAGS)
+libsquashfuse_ll_la_LIBADD = libsquashfuse.la libfuseprivate.la $(COMPRESSION_LIBS) \
   $(FUSE_LIBS)
 
+bin_PROGRAMS += squashfuse_ll
+squashfuse_ll_SOURCES = ll_main.c
+squashfuse_ll_CPPFLAGS = $(FUSE_CPPFLAGS)
+squashfuse_ll_LDADD = libsquashfuse.la libsquashfuse_ll.la $(COMPRESSION_LIBS) \
+  $(FUSE_LIBS)
+
+pkgconfig_DATA += squashfuse_ll.pc
+pkginclude_HEADERS += ll.h
 endif
 
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -37,6 +37,8 @@ libsquashfuse_convenience_la_LIBADD = $(COMPRESSION_LIBS) $(FUSE_LIBS)
 # Main library: libsquashfuse
 lib_LTLIBRARIES += libsquashfuse.la
 libsquashfuse_la_SOURCES =
+libsquashfuse_la_CPPFLAGS = $(ZLIB_CPPFLAGS) $(XZ_CPPFLAGS) $(LZO_CPPFLAGS) \
+	$(LZ4_CPPFLAGS) $(ZSTD_CPPFLAGS) $(FUSE_CPPFLAGS)
 libsquashfuse_la_LIBADD = libsquashfuse_convenience.la
 
 if SQ_WANT_FUSE
@@ -44,7 +46,7 @@ if SQ_WANT_FUSE
 libfuseprivate_la_SOURCES = fuseprivate.c nonstd-makedev.c nonstd-enoattr.c \
 	fuseprivate.h stat.h stat.c
 libfuseprivate_la_CPPFLAGS = $(FUSE_CPPFLAGS)
-libfuseprivate_la_LIBADD =
+libfuseprivate_la_LIBADD = $(COMPRESSION_LIBS) $(FUSE_LIBS)
 noinst_LTLIBRARIES += libfuseprivate.la
 endif
 
@@ -52,7 +54,9 @@ endif
 if SQ_WANT_HIGHLEVEL
 bin_PROGRAMS += squashfuse
 squashfuse_SOURCES = hl.c
-squashfuse_LDADD = libsquashfuse_convenience.la libfuseprivate.la
+squashfuse_CPPFLAGS = $(ZLIB_CPPFLAGS) $(XZ_CPPFLAGS) $(LZO_CPPFLAGS) \
+	$(LZ4_CPPFLAGS) $(ZSTD_CPPFLAGS) $(FUSE_CPPFLAGS)
+squashfuse_LDADD = libsquashfuse_convenience.la libfuseprivate.la $(COMPRESSION_LIBS) $(FUSE_LIBS)
 dist_man_MANS += squashfuse.1
 endif
 
@@ -67,12 +71,16 @@ libsquashfuse_ll_convenience_la_LIBADD = libsquashfuse_convenience.la libfusepri
 # squashfuse_ll library we will install
 lib_LTLIBRARIES += libsquashfuse_ll.la
 libsquashfuse_ll_la_SOURCES =
-libsquashfuse_ll_la_LIBADD = libsquashfuse_ll_convenience.la
+libsquashfuse_ll_la_CPPFLAGS = $(ZLIB_CPPFLAGS) $(XZ_CPPFLAGS) $(LZO_CPPFLAGS) \
+	$(LZ4_CPPFLAGS) $(ZSTD_CPPFLAGS) $(FUSE_CPPFLAGS)
+libsquashfuse_ll_la_LIBADD = libsquashfuse_ll_convenience.la $(COMPRESSION_LIBS) $(FUSE_LIBS)
 
 # squashfuse_ll binary that's statically linked against internal libs
 bin_PROGRAMS += squashfuse_ll
 squashfuse_ll_SOURCES = ll_main.c
-squashfuse_ll_LDADD = libsquashfuse_ll_convenience.la
+squashfuse_ll_CPPFLAGS = $(ZLIB_CPPFLAGS) $(XZ_CPPFLAGS) $(LZO_CPPFLAGS) \
+	$(LZ4_CPPFLAGS) $(ZSTD_CPPFLAGS) $(FUSE_CPPFLAGS)
+squashfuse_ll_LDADD = libsquashfuse_ll_convenience.la $(COMPRESSION_LIBS) $(FUSE_LIBS)
 
 pkgconfig_DATA += squashfuse_ll.pc
 pkginclude_HEADERS += ll.h

--- a/Makefile.am
+++ b/Makefile.am
@@ -66,6 +66,8 @@ if SQ_WANT_LOWLEVEL
 # convenience lib so we can link squashfuse_ll statically
 noinst_LTLIBRARIES += libsquashfuse_ll_convenience.la
 libsquashfuse_ll_convenience_la_SOURCES = ll.c ll_inode.c nonstd-daemon.c
+libsquashfuse_ll_convenience_la_CPPFLAGS = $(ZLIB_CPPFLAGS) $(XZ_CPPFLAGS) $(LZO_CPPFLAGS) \
+	$(LZ4_CPPFLAGS) $(ZSTD_CPPFLAGS) $(FUSE_CPPFLAGS)
 libsquashfuse_ll_convenience_la_LIBADD = libsquashfuse_convenience.la libfuseprivate.la
 
 # squashfuse_ll library we will install

--- a/Makefile.am
+++ b/Makefile.am
@@ -12,28 +12,32 @@ EXTRA_DIST = gen_swap.sh autogen.sh LICENSE CONFIGURATION PLATFORMS NEWS win
 
 bin_PROGRAMS =
 noinst_PROGRAMS =
-
-lib_LTLIBRARIES = libsquashfuse.la
+lib_LTLIBRARIES = 
 noinst_LTLIBRARIES =
 
 pkgincludedir = @includedir@/squashfuse
 pkginclude_HEADERS = squashfuse.h squashfs_fs.h \
 	cache.h common.h config.h decompress.h dir.h file.h fs.h stack.h table.h \
 	traverse.h util.h xattr.h
-
 pkgconfigdir = @pkgconfigdir@
 pkgconfig_DATA 	= squashfuse.pc
 
-# Main library: libsquashfuse
-libsquashfuse_la_SOURCES = swap.c cache.c table.c dir.c file.c fs.c \
+# Convenience lib to we get static executables
+noinst_LTLIBRARIES += libsquashfuse_convenience.la
+libsquashfuse_convenience_la_SOURCES = swap.c cache.c table.c dir.c file.c fs.c \
 	decompress.c xattr.c hash.c stack.c traverse.c util.c \
 	nonstd-pread.c nonstd-stat.c \
 	squashfs_fs.h common.h nonstd-internal.h nonstd.h swap.h cache.h table.h \
 	dir.h file.h decompress.h xattr.h squashfuse.h hash.h stack.h traverse.h \
 	util.h fs.h
-libsquashfuse_la_CPPFLAGS = $(ZLIB_CPPFLAGS) $(XZ_CPPFLAGS) $(LZO_CPPFLAGS) \
-	$(LZ4_CPPFLAGS) $(ZSTD_CPPFLAGS)
-libsquashfuse_la_LIBADD =
+libsquashfuse_convenience_la_CPPFLAGS = $(ZLIB_CPPFLAGS) $(XZ_CPPFLAGS) $(LZO_CPPFLAGS) \
+	$(LZ4_CPPFLAGS) $(ZSTD_CPPFLAGS) $(FUSE_CPPFLAGS)
+libsquashfuse_convenience_la_LIBADD = $(COMPRESSION_LIBS) $(FUSE_LIBS)
+
+# Main library: libsquashfuse
+lib_LTLIBRARIES += libsquashfuse.la
+libsquashfuse_la_SOURCES =
+libsquashfuse_la_LIBADD = libsquashfuse_convenience.la
 
 if SQ_WANT_FUSE
 # Helper for FUSE clients: libfuseprivate
@@ -48,26 +52,27 @@ endif
 if SQ_WANT_HIGHLEVEL
 bin_PROGRAMS += squashfuse
 squashfuse_SOURCES = hl.c
-squashfuse_CPPFLAGS = $(FUSE_CPPFLAGS)
-squashfuse_LDADD = libsquashfuse.la libfuseprivate.la $(COMPRESSION_LIBS) \
-  $(FUSE_LIBS)
-
+squashfuse_LDADD = libsquashfuse_convenience.la libfuseprivate.la
 dist_man_MANS += squashfuse.1
 endif
 
 # Low-level squashfuse_ll, if supported
 if SQ_WANT_LOWLEVEL
-lib_LTLIBRARIES += libsquashfuse_ll.la
-libsquashfuse_ll_la_SOURCES = ll.c ll_inode.c nonstd-daemon.c
-libsquashfuse_ll_la_CPPFLAGS = $(FUSE_CPPFLAGS)
-libsquashfuse_ll_la_LIBADD = libsquashfuse.la libfuseprivate.la $(COMPRESSION_LIBS) \
-  $(FUSE_LIBS)
 
+# convenience lib so we can link squashfuse_ll statically
+noinst_LTLIBRARIES += libsquashfuse_ll_convenience.la
+libsquashfuse_ll_convenience_la_SOURCES = ll.c ll_inode.c nonstd-daemon.c
+libsquashfuse_ll_convenience_la_LIBADD = libsquashfuse_convenience.la libfuseprivate.la
+
+# squashfuse_ll library we will install
+lib_LTLIBRARIES += libsquashfuse_ll.la
+libsquashfuse_ll_la_SOURCES =
+libsquashfuse_ll_la_LIBADD = libsquashfuse_ll_convenience.la
+
+# squashfuse_ll binary that's statically linked against internal libs
 bin_PROGRAMS += squashfuse_ll
 squashfuse_ll_SOURCES = ll_main.c
-squashfuse_ll_CPPFLAGS = $(FUSE_CPPFLAGS)
-squashfuse_ll_LDADD = libsquashfuse.la libsquashfuse_ll.la $(COMPRESSION_LIBS) \
-  $(FUSE_LIBS)
+squashfuse_ll_LDADD = libsquashfuse_ll_convenience.la
 
 pkgconfig_DATA += squashfuse_ll.pc
 pkginclude_HEADERS += ll.h
@@ -103,6 +108,6 @@ tests/ll-smoke.sh tests/ls.sh: tests/lib.sh
 # Handle generation of swap include files
 CLEANFILES = swap.h.inc swap.c.inc
 EXTRA_DIST += swap.h.inc swap.c.inc
-$(libsquashfuse_la_OBJECTS): swap.h.inc
+$(libsquashfuse_convenience_la_OBJECTS): swap.h.inc
 swap.h.inc swap.c.inc: gen_swap.sh squashfs_fs.h Makefile
 	SED="$(SED)" $(srcdir)/gen_swap.sh $(srcdir)/squashfs_fs.h

--- a/configure.ac
+++ b/configure.ac
@@ -100,7 +100,7 @@ AC_SUBST([sq_high_level])
 AC_SUBST([sq_low_level])
 AC_SUBST([sq_demo])
 AC_SUBST([sq_tests])
-AC_CONFIG_FILES([Makefile squashfuse.pc tests/lib.sh ci/features])
+AC_CONFIG_FILES([Makefile squashfuse.pc squashfuse_ll.pc tests/lib.sh ci/features])
 AC_OUTPUT
 
 AS_ECHO()

--- a/ll.c
+++ b/ll.c
@@ -52,7 +52,7 @@ static sig_atomic_t open_refcount = 0;
 /* same as lib/fuse_signals.c */
 static struct fuse_session *fuse_instance = NULL;
 
-static void sqfs_ll_op_getattr(fuse_req_t req, fuse_ino_t ino,
+void sqfs_ll_op_getattr(fuse_req_t req, fuse_ino_t ino,
 		struct fuse_file_info *fi) {
 	sqfs_ll_i lli;
 	struct stat st;
@@ -68,7 +68,7 @@ static void sqfs_ll_op_getattr(fuse_req_t req, fuse_ino_t ino,
 	}
 }
 
-static void sqfs_ll_op_opendir(fuse_req_t req, fuse_ino_t ino,
+void sqfs_ll_op_opendir(fuse_req_t req, fuse_ino_t ino,
 		struct fuse_file_info *fi) {
 	sqfs_ll_i *lli;
 	last_access = time(NULL);
@@ -94,13 +94,13 @@ static void sqfs_ll_op_opendir(fuse_req_t req, fuse_ino_t ino,
 	free(lli);
 }
 
-static void sqfs_ll_op_create(fuse_req_t req, fuse_ino_t parent, const char *name,
+void sqfs_ll_op_create(fuse_req_t req, fuse_ino_t parent, const char *name,
 			      mode_t mode, struct fuse_file_info *fi) {
 	last_access = time(NULL);
 	fuse_reply_err(req, EROFS);
 }
 
-static void sqfs_ll_op_releasedir(fuse_req_t req, fuse_ino_t ino,
+void sqfs_ll_op_releasedir(fuse_req_t req, fuse_ino_t ino,
 		struct fuse_file_info *fi) {
 	last_access = time(NULL);
 	--open_refcount;
@@ -108,7 +108,7 @@ static void sqfs_ll_op_releasedir(fuse_req_t req, fuse_ino_t ino,
 	fuse_reply_err(req, 0); /* yes, this is necessary */
 }
 
-static size_t sqfs_ll_add_direntry(fuse_req_t req, char *buf, size_t bufsize,
+size_t sqfs_ll_add_direntry(fuse_req_t req, char *buf, size_t bufsize,
 		const char *name, const struct stat *st, off_t off) {
 	#if HAVE_DECL_FUSE_ADD_DIRENTRY
 		return fuse_add_direntry(req, buf, bufsize, name, st, off);
@@ -119,7 +119,7 @@ static size_t sqfs_ll_add_direntry(fuse_req_t req, char *buf, size_t bufsize,
 		return esize;
 	#endif
 }
-static void sqfs_ll_op_readdir(fuse_req_t req, fuse_ino_t ino, size_t size,
+void sqfs_ll_op_readdir(fuse_req_t req, fuse_ino_t ino, size_t size,
 		off_t off, struct fuse_file_info *fi) {
 	sqfs_err sqerr;
 	sqfs_dir dir;
@@ -164,7 +164,7 @@ static void sqfs_ll_op_readdir(fuse_req_t req, fuse_ino_t ino, size_t size,
 	free(buf);
 }
 
-static void sqfs_ll_op_lookup(fuse_req_t req, fuse_ino_t parent,
+void sqfs_ll_op_lookup(fuse_req_t req, fuse_ino_t parent,
 		const char *name) {
 	sqfs_ll_i lli;
 	sqfs_err sqerr;
@@ -218,7 +218,7 @@ static void sqfs_ll_op_lookup(fuse_req_t req, fuse_ino_t parent,
 	}
 }
 
-static void sqfs_ll_op_open(fuse_req_t req, fuse_ino_t ino,
+void sqfs_ll_op_open(fuse_req_t req, fuse_ino_t ino,
 		struct fuse_file_info *fi) {
 	sqfs_inode *inode;
 	sqfs_ll *ll;
@@ -250,7 +250,7 @@ static void sqfs_ll_op_open(fuse_req_t req, fuse_ino_t ino,
 	free(inode);
 }
 
-static void sqfs_ll_op_release(fuse_req_t req, fuse_ino_t ino,
+void sqfs_ll_op_release(fuse_req_t req, fuse_ino_t ino,
 		struct fuse_file_info *fi) {
 	free((sqfs_inode*)(intptr_t)fi->fh);
 	fi->fh = 0;
@@ -259,7 +259,7 @@ static void sqfs_ll_op_release(fuse_req_t req, fuse_ino_t ino,
 	fuse_reply_err(req, 0);
 }
 
-static void sqfs_ll_op_read(fuse_req_t req, fuse_ino_t ino,
+void sqfs_ll_op_read(fuse_req_t req, fuse_ino_t ino,
 		size_t size, off_t off, struct fuse_file_info *fi) {
 	sqfs_ll *ll = fuse_req_userdata(req);
 	sqfs_inode *inode = (sqfs_inode*)(intptr_t)fi->fh;
@@ -285,7 +285,7 @@ static void sqfs_ll_op_read(fuse_req_t req, fuse_ino_t ino,
 	free(buf);
 }
 
-static void sqfs_ll_op_readlink(fuse_req_t req, fuse_ino_t ino) {
+void sqfs_ll_op_readlink(fuse_req_t req, fuse_ino_t ino) {
 	char *dst;
 	size_t size;
 	sqfs_ll_i lli;
@@ -308,7 +308,7 @@ static void sqfs_ll_op_readlink(fuse_req_t req, fuse_ino_t ino) {
 	}
 }
 
-static void sqfs_ll_op_listxattr(fuse_req_t req, fuse_ino_t ino, size_t size) {
+void sqfs_ll_op_listxattr(fuse_req_t req, fuse_ino_t ino, size_t size) {
 	sqfs_ll_i lli;
 	char *buf;
 	int ferr;
@@ -334,7 +334,7 @@ static void sqfs_ll_op_listxattr(fuse_req_t req, fuse_ino_t ino, size_t size) {
 	free(buf);
 }
 
-static void sqfs_ll_op_getxattr(fuse_req_t req, fuse_ino_t ino,
+void sqfs_ll_op_getxattr(fuse_req_t req, fuse_ino_t ino,
 		const char *name, size_t size
 #ifdef FUSE_XATTR_POSITION
 		, uint32_t position
@@ -370,7 +370,7 @@ static void sqfs_ll_op_getxattr(fuse_req_t req, fuse_ino_t ino,
 	free(buf);
 }
 
-static void sqfs_ll_op_forget(fuse_req_t req, fuse_ino_t ino,
+void sqfs_ll_op_forget(fuse_req_t req, fuse_ino_t ino,
 		unsigned long nlookup) {
 	sqfs_ll_i lli;
 	last_access = time(NULL);
@@ -379,7 +379,7 @@ static void sqfs_ll_op_forget(fuse_req_t req, fuse_ino_t ino,
 	fuse_reply_none(req);
 }
 
-static void stfs_ll_op_statfs(fuse_req_t req, fuse_ino_t ino) {
+void stfs_ll_op_statfs(fuse_req_t req, fuse_ino_t ino) {
 	sqfs_ll *ll;
 	struct statvfs st;
 	int err;
@@ -395,16 +395,8 @@ static void stfs_ll_op_statfs(fuse_req_t req, fuse_ino_t ino) {
 
 /* Helpers to abstract out FUSE 2.5 vs 3.0+ differences */
 
-typedef struct {
-	int fd;
-	struct fuse_session *session;
-#if FUSE_USE_VERSION < 30
-	struct fuse_chan *ch;
-#endif
-} sqfs_ll_chan;
-
 #if FUSE_USE_VERSION >= 30
-static sqfs_err sqfs_ll_mount(
+sqfs_err sqfs_ll_mount(
 		sqfs_ll_chan *ch,
 		const char *mountpoint,
 		struct fuse_args *args,
@@ -423,7 +415,7 @@ static sqfs_err sqfs_ll_mount(
 	return SQFS_OK;
 }
 
-static void sqfs_ll_unmount(sqfs_ll_chan *ch, const char *mountpoint) {
+void sqfs_ll_unmount(sqfs_ll_chan *ch, const char *mountpoint) {
 	fuse_session_unmount(ch->session);
 	fuse_session_destroy(ch->session);
 	ch->session = NULL;
@@ -431,7 +423,7 @@ static void sqfs_ll_unmount(sqfs_ll_chan *ch, const char *mountpoint) {
 
 #else /* FUSE_USE_VERSION >= 30 */
 
-static void sqfs_ll_unmount(sqfs_ll_chan *ch, const char *mountpoint) {
+void sqfs_ll_unmount(sqfs_ll_chan *ch, const char *mountpoint) {
 	if (ch->session) {
 #if HAVE_DECL_FUSE_SESSION_REMOVE_CHAN
 		fuse_session_remove_chan(ch->ch);
@@ -446,7 +438,7 @@ static void sqfs_ll_unmount(sqfs_ll_chan *ch, const char *mountpoint) {
 #endif
 }
 
-static sqfs_err sqfs_ll_mount(
+sqfs_err sqfs_ll_mount(
 		sqfs_ll_chan *ch,
 		const char *mountpoint,
 		struct fuse_args *args,
@@ -492,7 +484,7 @@ static sqfs_err sqfs_ll_mount(
    triggering the idle timeout.
  */
 
-static void alarm_tick(int sig) {
+void alarm_tick(int sig) {
 	if (!fuse_instance || idle_timeout_secs == 0) {
 		return;
 	}
@@ -506,7 +498,7 @@ static void alarm_tick(int sig) {
 	alarm(1);  /* always reset our alarm */
 }
 
-static void setup_idle_timeout(struct fuse_session *se, unsigned int timeout_secs) {
+void setup_idle_timeout(struct fuse_session *se, unsigned int timeout_secs) {
 	last_access = time(NULL);
 	idle_timeout_secs = timeout_secs;
 
@@ -525,12 +517,12 @@ static void setup_idle_timeout(struct fuse_session *se, unsigned int timeout_sec
 	alarm(1);
 }
 
-static void teardown_idle_timeout() {
+void teardown_idle_timeout() {
 	alarm(0);
 	fuse_instance = NULL;
 }
 
-static sqfs_ll *sqfs_ll_open(const char *path, size_t offset) {
+sqfs_ll *sqfs_ll_open(const char *path, size_t offset) {
 	sqfs_ll *ll;
 	
 	ll = malloc(sizeof(*ll));
@@ -550,126 +542,4 @@ static sqfs_ll *sqfs_ll_open(const char *path, size_t offset) {
 		free(ll);
 	}
 	return NULL;
-}
-
-int main(int argc, char *argv[]) {
-	struct fuse_args args;
-	sqfs_opts opts;
-
-#if FUSE_USE_VERSION >= 30
-	struct fuse_cmdline_opts fuse_cmdline_opts;
-#else
-	struct {
-		char *mountpoint;
-		int mt, foreground;
-	} fuse_cmdline_opts;
-#endif
-	
-	int err;
-	sqfs_ll *ll;
-	struct fuse_opt fuse_opts[] = {
-		{"offset=%zu", offsetof(sqfs_opts, offset), 0},
-		{"timeout=%u", offsetof(sqfs_opts, idle_timeout_secs), 0},
-		FUSE_OPT_END
-	};
-	
-	struct fuse_lowlevel_ops sqfs_ll_ops;
-	memset(&sqfs_ll_ops, 0, sizeof(sqfs_ll_ops));
-	sqfs_ll_ops.getattr		= sqfs_ll_op_getattr;
-	sqfs_ll_ops.opendir		= sqfs_ll_op_opendir;
-	sqfs_ll_ops.releasedir	= sqfs_ll_op_releasedir;
-	sqfs_ll_ops.readdir		= sqfs_ll_op_readdir;
-	sqfs_ll_ops.lookup		= sqfs_ll_op_lookup;
-	sqfs_ll_ops.open		= sqfs_ll_op_open;
-	sqfs_ll_ops.create		= sqfs_ll_op_create;
-	sqfs_ll_ops.release		= sqfs_ll_op_release;
-	sqfs_ll_ops.read		= sqfs_ll_op_read;
-	sqfs_ll_ops.readlink	= sqfs_ll_op_readlink;
-	sqfs_ll_ops.listxattr	= sqfs_ll_op_listxattr;
-	sqfs_ll_ops.getxattr	= sqfs_ll_op_getxattr;
-	sqfs_ll_ops.forget		= sqfs_ll_op_forget;
-	sqfs_ll_ops.statfs    = stfs_ll_op_statfs;
-   
-	/* PARSE ARGS */
-	args.argc = argc;
-	args.argv = argv;
-	args.allocated = 0;
-	
-	opts.progname = argv[0];
-	opts.image = NULL;
-	opts.mountpoint = 0;
-	opts.offset = 0;
-	opts.idle_timeout_secs = 0;
-	if (fuse_opt_parse(&args, &opts, fuse_opts, sqfs_opt_proc) == -1)
-		sqfs_usage(argv[0], true);
-
-#if FUSE_USE_VERSION >= 30
-	if (fuse_parse_cmdline(&args, &fuse_cmdline_opts) != 0)
-#else
-	if (fuse_parse_cmdline(&args,
-                           &fuse_cmdline_opts.mountpoint,
-                           &fuse_cmdline_opts.mt,
-                           &fuse_cmdline_opts.foreground) == -1)
-#endif
-		sqfs_usage(argv[0], true);
-	if (fuse_cmdline_opts.mountpoint == NULL)
-		sqfs_usage(argv[0], true);
-
-	/* fuse_daemonize() will unconditionally clobber fds 0-2.
-	 *
-	 * If we get one of these file descriptors in sqfs_ll_open,
-	 * we're going to have a bad time. Just make sure that all
-	 * these fds are open before opening the image file, that way
-	 * we must get a different fd.
-	 */
-	while (true) {
-	    int fd = open("/dev/null", O_RDONLY);
-	    if (fd == -1) {
-		/* Can't open /dev/null, how bizarre! However,
-		 * fuse_deamonize won't clobber fds if it can't
-		 * open /dev/null either, so we ought to be OK.
-		 */
-		break;
-	    }
-	    if (fd > 2) {
-		/* fds 0-2 are now guaranteed to be open. */
-		close(fd);
-		break;
-	    }
-	}
-
-	/* OPEN FS */
-	err = !(ll = sqfs_ll_open(opts.image, opts.offset));
-	
-	/* STARTUP FUSE */
-	if (!err) {
-		sqfs_ll_chan ch;
-		err = -1;
-		if (sqfs_ll_mount(
-                        &ch,
-                        fuse_cmdline_opts.mountpoint,
-                        &args,
-                        &sqfs_ll_ops,
-                        sizeof(sqfs_ll_ops),
-                        ll) == SQFS_OK) {
-			if (sqfs_ll_daemonize(fuse_cmdline_opts.foreground) != -1) {
-				if (fuse_set_signal_handlers(ch.session) != -1) {
-					if (opts.idle_timeout_secs) {
-						setup_idle_timeout(ch.session, opts.idle_timeout_secs);
-					}
-					/* FIXME: multithreading */
-					err = fuse_session_loop(ch.session);
-					teardown_idle_timeout();
-					fuse_remove_signal_handlers(ch.session);
-				}
-			}
-			sqfs_ll_destroy(ll);
-			sqfs_ll_unmount(&ch, fuse_cmdline_opts.mountpoint);
-		}
-	}
-	fuse_opt_free_args(&args);
-	free(ll);
-	free(fuse_cmdline_opts.mountpoint);
-	
-	return -err;
 }

--- a/ll.h
+++ b/ll.h
@@ -71,4 +71,95 @@ sqfs_err sqfs_ll_iget(fuse_req_t req, sqfs_ll_i *lli, fuse_ino_t i);
 
 int sqfs_ll_daemonize(int fg);
 
+void sqfs_ll_op_getattr(fuse_req_t req, fuse_ino_t ino,
+	struct fuse_file_info *fi);
+
+void sqfs_ll_op_opendir(fuse_req_t req, fuse_ino_t ino,
+	struct fuse_file_info *fi);
+
+void sqfs_ll_op_create(fuse_req_t req, fuse_ino_t parent, const char *name,
+	mode_t mode, struct fuse_file_info *fi);
+
+void sqfs_ll_op_releasedir(fuse_req_t req, fuse_ino_t ino,
+	struct fuse_file_info *fi);
+
+size_t sqfs_ll_add_direntry(fuse_req_t req, char *buf, size_t bufsize,
+	const char *name, const struct stat *st, off_t off);
+
+void sqfs_ll_op_readdir(fuse_req_t req, fuse_ino_t ino, size_t size,
+	off_t off, struct fuse_file_info *fi);
+
+void sqfs_ll_op_lookup(fuse_req_t req, fuse_ino_t parent,
+		const char *name);
+
+void sqfs_ll_op_open(fuse_req_t req, fuse_ino_t ino,
+		struct fuse_file_info *fi);
+
+void sqfs_ll_op_release(fuse_req_t req, fuse_ino_t ino,
+		struct fuse_file_info *fi);
+
+void sqfs_ll_op_read(fuse_req_t req, fuse_ino_t ino,
+		size_t size, off_t off, struct fuse_file_info *fi);
+
+void sqfs_ll_op_readlink(fuse_req_t req, fuse_ino_t ino);
+
+void sqfs_ll_op_listxattr(fuse_req_t req, fuse_ino_t ino, size_t size);
+
+void sqfs_ll_op_getxattr(fuse_req_t req, fuse_ino_t ino,
+		const char *name, size_t size
+#ifdef FUSE_XATTR_POSITION
+		, uint32_t position
+#endif
+		);
+
+void sqfs_ll_op_forget(fuse_req_t req, fuse_ino_t ino,
+		unsigned long nlookup);
+
+void stfs_ll_op_statfs(fuse_req_t req, fuse_ino_t ino);
+
+
+/* Helpers to abstract out FUSE 2.5 vs 3.0+ differences */
+
+typedef struct {
+	int fd;
+	struct fuse_session *session;
+#if FUSE_USE_VERSION < 30
+	struct fuse_chan *ch;
+#endif
+} sqfs_ll_chan;
+
+#if FUSE_USE_VERSION >= 30
+sqfs_err sqfs_ll_mount(
+		sqfs_ll_chan *ch,
+		const char *mountpoint,
+		struct fuse_args *args,
+        struct fuse_lowlevel_ops *ops,
+        size_t ops_size,
+        void *userdata);
+
+void sqfs_ll_unmount(sqfs_ll_chan *ch, const char *mountpoint);
+
+#else /* FUSE_USE_VERSION >= 30 */
+
+void sqfs_ll_unmount(sqfs_ll_chan *ch, const char *mountpoint);
+
+sqfs_err sqfs_ll_mount(
+		sqfs_ll_chan *ch,
+		const char *mountpoint,
+		struct fuse_args *args,
+		struct fuse_lowlevel_ops *ops,
+		size_t ops_size,
+		void *userdata);
+
+#endif /* FUSE_USE_VERSION >= 30 */
+
+void alarm_tick(int sig);
+
+void setup_idle_timeout(struct fuse_session *se, unsigned int timeout_secs);
+
+void teardown_idle_timeout();
+
+sqfs_ll *sqfs_ll_open(const char *path, size_t offset);
+
+
 #endif

--- a/ll_main.c
+++ b/ll_main.c
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2012 Dave Vasilevsky <dave@vasilevsky.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "ll.h"
+#include "fuseprivate.h"
+#include "stat.h"
+
+#include "nonstd.h"
+
+#include <errno.h>
+#include <float.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <signal.h>
+#include <unistd.h>
+
+int main(int argc, char *argv[]) {
+	struct fuse_args args;
+	sqfs_opts opts;
+
+#if FUSE_USE_VERSION >= 30
+	struct fuse_cmdline_opts fuse_cmdline_opts;
+#else
+	struct {
+		char *mountpoint;
+		int mt, foreground;
+	} fuse_cmdline_opts;
+#endif
+	
+	int err;
+	sqfs_ll *ll;
+	struct fuse_opt fuse_opts[] = {
+		{"offset=%zu", offsetof(sqfs_opts, offset), 0},
+		{"timeout=%u", offsetof(sqfs_opts, idle_timeout_secs), 0},
+		FUSE_OPT_END
+	};
+	
+	struct fuse_lowlevel_ops sqfs_ll_ops;
+	memset(&sqfs_ll_ops, 0, sizeof(sqfs_ll_ops));
+	sqfs_ll_ops.getattr		= sqfs_ll_op_getattr;
+	sqfs_ll_ops.opendir		= sqfs_ll_op_opendir;
+	sqfs_ll_ops.releasedir	= sqfs_ll_op_releasedir;
+	sqfs_ll_ops.readdir		= sqfs_ll_op_readdir;
+	sqfs_ll_ops.lookup		= sqfs_ll_op_lookup;
+	sqfs_ll_ops.open		= sqfs_ll_op_open;
+	sqfs_ll_ops.create		= sqfs_ll_op_create;
+	sqfs_ll_ops.release		= sqfs_ll_op_release;
+	sqfs_ll_ops.read		= sqfs_ll_op_read;
+	sqfs_ll_ops.readlink	= sqfs_ll_op_readlink;
+	sqfs_ll_ops.listxattr	= sqfs_ll_op_listxattr;
+	sqfs_ll_ops.getxattr	= sqfs_ll_op_getxattr;
+	sqfs_ll_ops.forget		= sqfs_ll_op_forget;
+	sqfs_ll_ops.statfs    = stfs_ll_op_statfs;
+   
+	/* PARSE ARGS */
+	args.argc = argc;
+	args.argv = argv;
+	args.allocated = 0;
+	
+	opts.progname = argv[0];
+	opts.image = NULL;
+	opts.mountpoint = 0;
+	opts.offset = 0;
+	opts.idle_timeout_secs = 0;
+	if (fuse_opt_parse(&args, &opts, fuse_opts, sqfs_opt_proc) == -1)
+		sqfs_usage(argv[0], true);
+
+#if FUSE_USE_VERSION >= 30
+	if (fuse_parse_cmdline(&args, &fuse_cmdline_opts) != 0)
+#else
+	if (fuse_parse_cmdline(&args,
+                           &fuse_cmdline_opts.mountpoint,
+                           &fuse_cmdline_opts.mt,
+                           &fuse_cmdline_opts.foreground) == -1)
+#endif
+		sqfs_usage(argv[0], true);
+	if (fuse_cmdline_opts.mountpoint == NULL)
+		sqfs_usage(argv[0], true);
+
+	/* fuse_daemonize() will unconditionally clobber fds 0-2.
+	 *
+	 * If we get one of these file descriptors in sqfs_ll_open,
+	 * we're going to have a bad time. Just make sure that all
+	 * these fds are open before opening the image file, that way
+	 * we must get a different fd.
+	 */
+	while (true) {
+	    int fd = open("/dev/null", O_RDONLY);
+	    if (fd == -1) {
+		/* Can't open /dev/null, how bizarre! However,
+		 * fuse_deamonize won't clobber fds if it can't
+		 * open /dev/null either, so we ought to be OK.
+		 */
+		break;
+	    }
+	    if (fd > 2) {
+		/* fds 0-2 are now guaranteed to be open. */
+		close(fd);
+		break;
+	    }
+	}
+
+	/* OPEN FS */
+	err = !(ll = sqfs_ll_open(opts.image, opts.offset));
+	
+	/* STARTUP FUSE */
+	if (!err) {
+		sqfs_ll_chan ch;
+		err = -1;
+		if (sqfs_ll_mount(
+                        &ch,
+                        fuse_cmdline_opts.mountpoint,
+                        &args,
+                        &sqfs_ll_ops,
+                        sizeof(sqfs_ll_ops),
+                        ll) == SQFS_OK) {
+			if (sqfs_ll_daemonize(fuse_cmdline_opts.foreground) != -1) {
+				if (fuse_set_signal_handlers(ch.session) != -1) {
+					if (opts.idle_timeout_secs) {
+						setup_idle_timeout(ch.session, opts.idle_timeout_secs);
+					}
+					/* FIXME: multithreading */
+					err = fuse_session_loop(ch.session);
+					teardown_idle_timeout();
+					fuse_remove_signal_handlers(ch.session);
+				}
+			}
+			sqfs_ll_destroy(ll);
+			sqfs_ll_unmount(&ch, fuse_cmdline_opts.mountpoint);
+		}
+	}
+	fuse_opt_free_args(&args);
+	free(ll);
+	free(fuse_cmdline_opts.mountpoint);
+	
+	return -err;
+}

--- a/squashfuse_ll.pc.in
+++ b/squashfuse_ll.pc.in
@@ -1,0 +1,12 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@/squashfuse
+
+Name: squashfuse_ll
+Description: squashfuse low-level library to mount squashfs archives
+Version: @VERSION@
+
+Requires:
+Libs: -L${libdir} -lsquashfuse -lsquashfuse_ll
+Cflags: -I${includedir}


### PR DESCRIPTION
This makes it easier for people to statically link squashfuse_ll into
their application, which can in turn be used to more easily ship
self-exectracting binaries (e.g. facebook xar or appimage)
