### PR TITLE
Install ALL headers

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -17,8 +17,9 @@ noinst_LTLIBRARIES =
 
 pkgincludedir = @includedir@/squashfuse
 pkginclude_HEADERS = squashfuse.h squashfs_fs.h \
-	cache.h common.h config.h decompress.h dir.h file.h fs.h stack.h table.h \
-	traverse.h util.h xattr.h
+	cache.h common.h config.h decompress.h dir.h file.h fs.h \
+	fuseprivate.h hash.h nonstd.h nonstd-internal.h \
+	stack.h stat.h swap.h table.h traverse.h util.h xattr.h
 pkgconfigdir = @pkgconfigdir@
 pkgconfig_DATA 	= squashfuse.pc
 


### PR DESCRIPTION
Back in #36 I submitted a PR to fix installation of the header files. At the time, I included only the ones that were `#included` from `squashfuse.h` itself, making that header file `#include`-able.

I figured the other headers that weren't referenced were probably private API that could be omitted.

Well, whether they were intended that way or not, wouldn't you know, [at least one project needs them](https://github.com/AppImage/AppImageKit/blob/1f739c1bea7e0b8bb91c66011492515acb3ae9fc/src/runtime.c#L32-L34). AppImageKit, which uses `sqfs_makedev()` from `nonstd-makedev.c`, will fail on a missing `nonstd.h` when attempting to build against a squashfuse installed with the current header configuration.

This PR thus updates the config to install _every_ header in the repo. 

This includes 'fuseprivate.h' and 'nonstd-internal.h' which may _**really**_ be private API. I've included them for the sake of completeness, but I can remove either or both if you'd prefer.