### PR TITLE
Fix fuse_mount function argument probing

### DIFF
--- a/m4/squashfuse_fuse.m4
+++ b/m4/squashfuse_fuse.m4
@@ -260,7 +260,9 @@ AC_DEFUN([SQ_FUSE_API_VERSION],[
 		AC_CACHE_CHECK([for two-argument fuse_unmount],
 				[sq_cv_decl_fuse_unmount_two_arg],[
 			AC_LINK_IFELSE(
-				[AC_LANG_PROGRAM([#include <fuse_lowlevel.h>],
+				[AC_LANG_PROGRAM([
+				#include <fuse.h>
+				#include <fuse_lowlevel.h>],
 					[fuse_unmount(0,0)])],
 				[sq_cv_decl_fuse_unmount_two_arg=yes],
 				[sq_cv_decl_fuse_unmount_two_arg=no])


### PR DESCRIPTION
The test did not check the number of arguments with certain fuse headers because they declare fuse_mount in <fuse.h>, not <fuse_lowlevel.h>.  If the compile supports implicit function declarations, the test always succeeds (regardless of parameter count).  If it does not, it always fails.

Found as part of:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC