### PR TITLE
Correct the order of xattr prefixes, swapping trusted and security

### DIFF
--- a/xattr.c
+++ b/xattr.c
@@ -41,8 +41,8 @@ typedef struct {
  
 sqfs_prefix sqfs_xattr_prefixes[] = {
 	{"user.", 5},
-	{"security.", 9},
 	{"trusted.", 8},
+	{"security.", 9},
 };
 
 


### PR DESCRIPTION
I found that when selinux is enabled when mksquashfs is run, it adds an extended attribute that the kernel squashfs shows (in an strace of attr -l) as `security.selinux`, but squashfuse shows it as `trusted.selinux`.  That's because the extended attribute types for trusted and selinux as defined in [squashfs_fs.h](https://github.com/vasi/squashfuse/blob/0.1.105/squashfs_fs.h#L97) are defined as 1 & 2, respectively, but their names as listed in [xattr.c](https://github.com/vasi/squashfuse/blob/0.1.105/xattr.c#L44) are reversed.  As a result, attempts to look at that attribute (for example with strace -l) returns an ENODATA error.

This corrects the order of the two prefixes.