### PR TITLE
upload all logs from CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,9 +78,8 @@ jobs:
         with:
           name: logs
           path: |
-            config.log
+            *.log
             tests/*.log
-            mksquashfs.log
             ci/features
         if: always()
   windows:


### PR DESCRIPTION
I noticed that test-suite.log was not getting uploaded, so just upload *.log.