### PR TITLE
Save logs separately for each matrix element

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
       - name: upload
         uses: actions/upload-artifact@v2
         with:
-          name: logs
+          name: logs ${{ matrix.name }}
           path: |
             *.log
             tests/*.log


### PR DESCRIPTION
Previously each github action matrix test used the same name for the uploaded logs.  This keeps a separate set of logs for each one.