### PR TITLE
Enable low-level multithreading by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -98,7 +98,9 @@ AS_IF([test "x$sq_high_level$sq_low_level$sq_demo" = xnonono],
 	AC_MSG_FAILURE([Nothing left to build]))
 
 AC_ARG_ENABLE([multithreading],
- 	AS_HELP_STRING([--enable-multithreading], [enable multi-threaded low-level FUSE driver]),
+ 	AS_HELP_STRING([--disable-multithreading], [disable multi-threaded low-level FUSE driver]),,
+    [enable_multithreading="yes"])
+AS_IF([test x$enable_multithreading = xyes],
 	[
     AC_CHECK_LIB([pthread], [pthread_mutex_lock], [], AC_MSG_ERROR([libpthread is required for multithreaded build]))
     AC_DEFINE(SQFS_MULTITHREADED, 1, [Enable multi-threaded low-level FUSE driver])

--- a/fuseprivate.c
+++ b/fuseprivate.c
@@ -59,6 +59,14 @@ int sqfs_listxattr(sqfs *fs, sqfs_inode *inode, char *buf, size_t *size) {
 	return 0;
 }
 
+void sqfs_minimal_fuse_usage() {
+	fprintf(stderr, "\nSelection of FUSE options:\n");
+	fprintf(stderr,"    -h   --help            print help\n");
+	fprintf(stderr,"    -V   --version         print version\n");
+	fprintf(stderr,"    -d   -o debug          enable debug output (implies -f)\n");
+	fprintf(stderr,"    -f                     foreground operation\n");
+}
+
 void sqfs_usage(char *progname, bool fuse_usage, bool ll_usage) {
 	fprintf(stderr, "%s (c) 2012 Dave Vasilevsky\n\n", PACKAGE_STRING);
 	fprintf(stderr, "Usage: %s [options] ARCHIVE MOUNTPOINT\n",
@@ -72,6 +80,7 @@ void sqfs_usage(char *progname, bool fuse_usage, bool ll_usage) {
 	}
 	if (fuse_usage) {
 		if (ll_usage) {
+#ifdef SQFS_MULTITHREADED
 #if FUSE_USE_VERSION >= 30
 			fprintf(stderr, "\nFUSE options:\n");
 			fuse_cmdline_help();
@@ -82,15 +91,15 @@ void sqfs_usage(char *progname, bool fuse_usage, bool ll_usage) {
 			fprintf(stderr, "\n");
 			fuse_parse_cmdline(&args, NULL, NULL, NULL);
 #endif
+#else
+			/* Skip the multithreaded options */
+			sqfs_minimal_fuse_usage();
+#endif
 		} else {
 			/* Standard FUSE help includes confusing 
 			 * multi-threaded options so don't use it
 			 */
-			fprintf(stderr, "\nSelection of FUSE options:\n");
-			fprintf(stderr,"    -h   --help            print help\n");
-			fprintf(stderr,"    -V   --version         print version\n");
-			fprintf(stderr,"    -d   -o debug          enable debug output (implies -f)\n");
-			fprintf(stderr,"    -f                     foreground operation\n");
+			sqfs_minimal_fuse_usage();
 			fprintf(stderr,"    -o allow_other         allow access by other users\n");
 			fprintf(stderr,"    -o allow_root          allow access by the superuser\n");
 		}


### PR DESCRIPTION
This enables multithreading in squashfuse_ll by default, and when multithreading is disabled it removes the multithreading-related help options.  I think it's OK for the man page to describe the default so I didn't change that.

- Fixes #93
- Fixes #94
