### PR TITLE
add missing entries to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,8 @@ win/Release
 *.opensdf
 *.suo
 *.vcxproj.user
+
+ci/features
+tests/lib.sh
+tests/ll-smoke.sh
+tests/umount-test.sh


### PR DESCRIPTION
This PR adds the following entries to `.gitignore`, to avoid "uncommitted changes" after build:

```
ci/features
tests/lib.sh
tests/ll-smoke.sh
tests/umount-test.sh
```

Fixes #101 