### PR TITLE
Restore functions signatures

### DIFF
--- a/dir.c
+++ b/dir.c
@@ -279,7 +279,7 @@ sqfs_err sqfs_dir_lookup(sqfs *fs, sqfs_inode *inode,
 }
 
 
-sqfs_err sqfs_lookup_path(sqfs *fs, sqfs_inode *inode, const char *path,
+sqfs_err sqfs_lookup_path_with_id(sqfs *fs, sqfs_inode *inode, const char *path,
 		bool *found, sqfs_inode_id *id) {
 	sqfs_err err;
 	sqfs_name buf;
@@ -317,3 +317,8 @@ sqfs_err sqfs_lookup_path(sqfs *fs, sqfs_inode *inode, const char *path,
 	*found = true;
 	return SQFS_OK;
 }
+
+sqfs_err sqfs_lookup_path(sqfs *fs, sqfs_inode *inode, const char *path,
+		bool *found) {
+	return sqfs_lookup_path_with_id(fs, inode, path, found, NULL);
+};

--- a/dir.h
+++ b/dir.h
@@ -70,6 +70,11 @@ sqfs_err sqfs_dir_lookup(sqfs *fs, sqfs_inode *inode,
 /* Lookup a complete path, and replace *inode with the results.
 	 Uses / (slash) as the directory separator. */
 sqfs_err sqfs_lookup_path(sqfs *fs, sqfs_inode *inode, const char *path,
+	bool *found);
+
+/* Similar to sqfs_lookup_path, additionaly replaces *id
+   with sqfs_inode_id of inode */
+sqfs_err sqfs_lookup_path_with_id(sqfs *fs, sqfs_inode *inode, const char *path,
 	bool *found, sqfs_inode_id *id);
 
 

--- a/extract.c
+++ b/extract.c
@@ -59,7 +59,7 @@ int main(int argc, char *argv[]) {
     image = argv[1];
     path_to_extract = argv[2];
     
-    if ((err = sqfs_open_image(&fs, image, 0, NULL)))
+    if ((err = sqfs_open_image(&fs, image, 0)))
         exit(ERR_OPEN);
     
     if ((err = sqfs_traverse_open(&trv, &fs, sqfs_inode_root(&fs))))

--- a/fs.c
+++ b/fs.c
@@ -59,7 +59,7 @@ sqfs_compression_type sqfs_compression(sqfs *fs) {
 	return fs->sb.compression;
 }
 
-sqfs_err sqfs_init(sqfs *fs, sqfs_fd_t fd, size_t offset, const char *subdir) {
+sqfs_err sqfs_init_with_subdir(sqfs *fs, sqfs_fd_t fd, size_t offset, const char *subdir) {
 	sqfs_err err = SQFS_OK;
 	memset(fs, 0, sizeof(*fs));
 	
@@ -100,7 +100,7 @@ sqfs_err sqfs_init(sqfs *fs, sqfs_fd_t fd, size_t offset, const char *subdir) {
 		err |= sqfs_inode_get(fs, &root, sqfs_inode_root(fs));
 		sqfs_inode_id new_root;
 		bool found = false;
-		err |= sqfs_lookup_path(fs, &root, subdir, &found, &new_root);
+		err |= sqfs_lookup_path_with_id(fs, &root, subdir, &found, &new_root);
 		if (!found) {
 			sqfs_destroy(fs);
 			return SQFS_ERR;
@@ -114,6 +114,10 @@ sqfs_err sqfs_init(sqfs *fs, sqfs_fd_t fd, size_t offset, const char *subdir) {
 	}
 	
 	return SQFS_OK;
+}
+
+sqfs_err sqfs_init(sqfs *fs, sqfs_fd_t fd, size_t offset) {
+  return sqfs_init_with_subdir(fs, fd, offset, NULL);
 }
 
 void sqfs_destroy(sqfs *fs) {

--- a/fs.h
+++ b/fs.h
@@ -88,7 +88,8 @@ void sqfs_version_supported(int *min_major, int *min_minor, int *max_major,
 size_t sqfs_divceil(uint64_t total, size_t group);
 
 
-sqfs_err sqfs_init(sqfs *fs, sqfs_fd_t fd, size_t offset, const char *subdir);
+sqfs_err sqfs_init(sqfs *fs, sqfs_fd_t fd, size_t offset);
+sqfs_err sqfs_init_with_subdir(sqfs *fs, sqfs_fd_t fd, size_t offset, const char *subdir);
 void sqfs_destroy(sqfs *fs);
 
 /* Ok to call these even on incompletely constructed filesystems */

--- a/hl.c
+++ b/hl.c
@@ -51,7 +51,7 @@ static sqfs_err sqfs_hl_lookup(sqfs **fs, sqfs_inode *inode,
 		*inode = hl->root; /* copy */
 
 	if (path) {
-		sqfs_err err = sqfs_lookup_path(*fs, inode, path, &found, NULL);
+		sqfs_err err = sqfs_lookup_path(*fs, inode, path, &found);
 		if (err)
 			return err;
 		if (!found)
@@ -275,7 +275,7 @@ static sqfs_hl *sqfs_hl_open(const char *path, size_t offset, const char *subdir
 		perror("Can't allocate memory");
 	} else {
 		memset(hl, 0, sizeof(*hl));
-		if (sqfs_open_image(&hl->fs, path, offset, subdir) == SQFS_OK) {
+		if (sqfs_open_image_with_subdir(&hl->fs, path, offset, subdir) == SQFS_OK) {
 			if (sqfs_inode_get(&hl->fs, &hl->root, sqfs_inode_root(&hl->fs)))
 				fprintf(stderr, "Can't find the root of this filesystem!\n");
 			else

--- a/ll.c
+++ b/ll.c
@@ -562,7 +562,7 @@ void teardown_idle_timeout() {
 	fuse_instance = NULL;
 }
 
-sqfs_ll *sqfs_ll_open(const char *path, size_t offset, const char *subdir) {
+sqfs_ll *sqfs_ll_open_with_subdir(const char *path, size_t offset, const char *subdir) {
 	sqfs_ll *ll;
 	
 	ll = malloc(sizeof(*ll));
@@ -571,7 +571,7 @@ sqfs_ll *sqfs_ll_open(const char *path, size_t offset, const char *subdir) {
 	} else {
 		memset(ll, 0, sizeof(*ll));
 		ll->fs.offset = offset;
-		if (sqfs_open_image(&ll->fs, path, offset, subdir) == SQFS_OK) {
+		if (sqfs_open_image_with_subdir(&ll->fs, path, offset, subdir) == SQFS_OK) {
 			if (sqfs_ll_init(ll))
 				fprintf(stderr, "Can't initialize this filesystem!\n");
 			else
@@ -582,4 +582,8 @@ sqfs_ll *sqfs_ll_open(const char *path, size_t offset, const char *subdir) {
 		free(ll);
 	}
 	return NULL;
+}
+
+sqfs_ll *sqfs_ll_open(const char *path, size_t offset) {
+	return sqfs_ll_open_with_subdir(path, offset, NULL);
 }

--- a/ll.h
+++ b/ll.h
@@ -144,7 +144,8 @@ void setup_idle_timeout(struct fuse_session *se, unsigned int timeout_secs);
 
 void teardown_idle_timeout();
 
-sqfs_ll *sqfs_ll_open(const char *path, size_t offset, const char *subdir);
+sqfs_ll *sqfs_ll_open_with_subdir(const char *path, size_t offset, const char *subdir);
+sqfs_ll *sqfs_ll_open(const char *path, size_t offset);
 
 
 #endif

--- a/ll_main.c
+++ b/ll_main.c
@@ -214,7 +214,7 @@ int main(int argc, char *argv[]) {
 	}
 
 	/* OPEN FS */
-	err = !(ll = sqfs_ll_open(opts.image, opts.offset, opts.subdir));
+	err = !(ll = sqfs_ll_open_with_subdir(opts.image, opts.offset, opts.subdir));
 	
 	/* STARTUP FUSE */
 	if (!err) {

--- a/ls.c
+++ b/ls.c
@@ -56,7 +56,7 @@ int main(int argc, char *argv[]) {
 		usage();
 	image = argv[1];
 
-	if ((err = sqfs_open_image(&fs, image, 0, NULL)))
+	if ((err = sqfs_open_image(&fs, image, 0)))
 		exit(ERR_OPEN);
 	
 	if ((err = sqfs_traverse_open(&trv, &fs, sqfs_inode_root(&fs))))

--- a/util.c
+++ b/util.c
@@ -67,14 +67,14 @@
 
 /* TODO: WIN32 implementation of open/close */
 /* TODO: i18n of error messages */
-sqfs_err sqfs_open_image(sqfs *fs, const char *image, size_t offset, const char *subdir) {
+sqfs_err sqfs_open_image_with_subdir(sqfs *fs, const char *image, size_t offset, const char *subdir) {
 	sqfs_err err;
 	sqfs_fd_t fd;
 
 	if ((err = sqfs_fd_open(image, &fd, stderr)))
 		return err;
 
-	err = sqfs_init(fs, fd, offset, subdir);
+	err = sqfs_init_with_subdir(fs, fd, offset, subdir);
 	switch (err) {
 		case SQFS_OK:
 			break;
@@ -123,3 +123,6 @@ sqfs_err sqfs_open_image(sqfs *fs, const char *image, size_t offset, const char 
 	return err;
 }
 
+sqfs_err sqfs_open_image(sqfs *fs, const char *image, size_t offset) {
+	return sqfs_open_image_with_subdir(fs, image, offset, NULL);
+}

--- a/util.h
+++ b/util.h
@@ -35,7 +35,10 @@ sqfs_err sqfs_fd_open(const char *path, sqfs_fd_t *fd, bool print);
 /* Close a file */
 void sqfs_fd_close(sqfs_fd_t fd);
 
+/* Open a filesystem with subdir and print errors to stderr. */
+sqfs_err sqfs_open_image_with_subdir(sqfs *fs, const char *image, size_t offset, const char *subdir);
+
 /* Open a filesystem and print errors to stderr. */
-sqfs_err sqfs_open_image(sqfs *fs, const char *image, size_t offset, const char *subdir);
+sqfs_err sqfs_open_image(sqfs *fs, const char *image, size_t offset);
 
 #endif


### PR DESCRIPTION
`subdir` argument inroduced in 53e1b97 broke multiple applications depending on squashfuse.
To fix this functions that accept `subdir` arg now have `_with_subdir` suffix in them.
The old (unsuffixed) functions were reimplemented to call their `_with_subdir` counterparts with `subdir = NULL`.

Tested against libappimage (git commit `e56c21b5387fde92cbb91c835e7aa16ab60b3879`).

Fixes: #105