### PR TITLE
Fix header paths for fuse3

### DIFF
--- a/fuseprivate.c
+++ b/fuseprivate.c
@@ -32,6 +32,10 @@
 
 #include "nonstd.h"
 
+#if HAVE_DECL_FUSE_CMDLINE_HELP
+    #include <fuse_lowlevel.h>
+#endif
+
 int sqfs_listxattr(sqfs *fs, sqfs_inode *inode, char *buf, size_t *size) {
 	sqfs_xattr x;
 	size_t count = 0;
@@ -83,7 +87,7 @@ void sqfs_usage(char *progname, bool fuse_usage, bool ll_usage) {
 	if (fuse_usage) {
 		if (ll_usage) {
 #ifdef SQFS_MULTITHREADED
-#if FUSE_USE_VERSION >= 30
+#if HAVE_DECL_FUSE_CMDLINE_HELP
 			fprintf(stderr, "\nFUSE options:\n");
 			fuse_cmdline_help();
 #else

--- a/fuseprivate.h
+++ b/fuseprivate.h
@@ -27,12 +27,7 @@
 
 #include "squashfuse.h"
 
-#if FUSE_USE_VERSION >= 30
-#include <fuse3/fuse.h>
-#include <fuse3/fuse_lowlevel.h>
-#else
 #include <fuse.h>
-#endif
 
 /* Common functions for FUSE high- and low-level clients */
 

--- a/ll.h
+++ b/ll.h
@@ -27,11 +27,7 @@
 
 #include "squashfuse.h"
 
-#if FUSE_USE_VERSION >= 30
-#include <fuse3/fuse_lowlevel.h>
-#else
 #include <fuse_lowlevel.h>
-#endif
 
 typedef struct sqfs_ll sqfs_ll;
 struct sqfs_ll {

--- a/m4/squashfuse_fuse.m4
+++ b/m4/squashfuse_fuse.m4
@@ -271,6 +271,9 @@ AC_DEFUN([SQ_FUSE_API_VERSION],[
 			AC_DEFINE([HAVE_NEW_FUSE_UNMOUNT],1,
 					[Define if we have two-argument fuse_unmount])
 		])
+
+		AC_CHECK_DECLS([fuse_cmdline_help],,,
+		        [#include <fuse_lowlevel.h>])
 	])
 	
 	SQ_RESTORE_FLAGS

--- a/nonstd-daemon.c
+++ b/nonstd-daemon.c
@@ -28,11 +28,7 @@
 #include "nonstd-internal.h"
 
 #include <unistd.h>
-#if FUSE_USE_VERSION >= 30
-#include <fuse3/fuse_lowlevel.h>
-#else
 #include <fuse_lowlevel.h>
-#endif
 
 int sqfs_ll_daemonize(int fg) {
 	#if HAVE_DECL_FUSE_DAEMONIZE


### PR DESCRIPTION
We should look in the path that pkg-config gives us, not the default search paths.

Fixes #108 