### PR TITLE
Add a notification mechanism for signaling when the mountpoint is ready

### DIFF
--- a/fs.h
+++ b/fs.h
@@ -39,6 +39,7 @@ struct sqfs {
 	int uid;
 	int gid;
 	struct squashfs_super_block sb;
+	const char *notify_pipe;
 	sqfs_table id_table;
 	sqfs_table frag_table;
 	sqfs_table export_table;

--- a/fuseprivate.h
+++ b/fuseprivate.h
@@ -29,13 +29,16 @@
 
 #include <fuse.h>
 
+#define NOTIFY_SUCCESS 's'
+#define NOTIFY_FAILURE 'f'
+
 /* Common functions for FUSE high- and low-level clients */
 
 /* Populate an xattr list. Return an errno value. */
 int sqfs_listxattr(sqfs *fs, sqfs_inode *inode, char *buf, size_t *size);
 
 /* Print a usage string */
-void sqfs_usage(char *progname, bool fuse_usage, bool ll_usage);
+int sqfs_usage(char *progname, bool fuse_usage, bool ll_usage);
 
 /* Parse command-line arguments */
 typedef struct {
@@ -47,11 +50,14 @@ typedef struct {
 	unsigned int idle_timeout_secs;
 	int uid;
 	int gid;
+	const char *notify_pipe;
 } sqfs_opts;
 int sqfs_opt_proc(void *data, const char *arg, int key,
 	struct fuse_args *outargs);
 
 /* Get filesystem super block info */
 int sqfs_statfs(sqfs *sq, struct statvfs *st);
+void notify_mount_ready(const char *notify_pipe, char status);
+void notify_mount_ready_async(const char *notify_pipe, char status);
 
 #endif

--- a/ll.c
+++ b/ll.c
@@ -432,6 +432,12 @@ void stfs_ll_op_statfs(fuse_req_t req, fuse_ino_t ino) {
 	}
 }
 
+void sqfs_ll_op_init(void *userdata, struct fuse_conn_info *conn) {
+	sqfs_ll *ll = userdata;
+
+	notify_mount_ready_async(ll->fs.notify_pipe, NOTIFY_SUCCESS);
+}
+
 /* Helpers to abstract out FUSE 2.5 vs 3.0+ differences */
 
 #if FUSE_USE_VERSION >= 30

--- a/ll.h
+++ b/ll.h
@@ -111,6 +111,8 @@ void sqfs_ll_op_getxattr(fuse_req_t req, fuse_ino_t ino,
 void sqfs_ll_op_forget(fuse_req_t req, fuse_ino_t ino,
 		unsigned long nlookup);
 
+void sqfs_ll_op_init(void *userdata, struct fuse_conn_info *conn);
+
 void stfs_ll_op_statfs(fuse_req_t req, fuse_ino_t ino);
 
 

--- a/squashfuse.1
+++ b/squashfuse.1
@@ -57,6 +57,10 @@ offset N bytes into archive to mount
 .It Fl o Cm subdir=PATH
 mount subdirectory PATH as filesystem root
 .El
+.Bl -tag -width -indent
+.It Fl o Cm notify_pipe=PATH
+named pipe that will receive 's' (success) or 'f' (failure) when the mountpoint is ready
+.El
 .Pp
 Here is a selection of generally useful FUSE library options:
 .Bl -tag -width -indent

--- a/tests/ll-smoke.sh.in
+++ b/tests/ll-smoke.sh.in
@@ -60,20 +60,27 @@ for comp in $compressors; do
     mkdir -p "$WORKDIR/mount"
 
     echo "Mounting squashfs image..."
-    $SFLL -f $SFLL_EXTRA_ARGS "$WORKDIR/squashfs.image" "$WORKDIR/mount" >"$WORKDIR/squashfs_ll.log" 2>&1 &
-
-    # Wait up to 5 seconds to be mounted. TSAN builds can take some time to mount.
-    for _ in $(seq 5); do
-    if sq_is_mountpoint "$WORKDIR/mount"; then
-        break
+    FIFO_1=$(mktemp -u)
+    mkfifo "$FIFO_1"
+    $SFLL -f $SFLL_EXTRA_ARGS -o notify_pipe="$FIFO_1" "$WORKDIR/squashfs.image" "$WORKDIR/mount" >"$WORKDIR/squashfs_ll_1.log" 2>&1 &
+    # Wait for the archive to be mounted. TSAN builds can take some time to mount.
+    STATUS=$(head -c1 "$FIFO_1")
+    if [ "$STATUS" != "s" ]; then
+        echo "Image did not mount successfully"
+        cp "$WORKDIR/squashfs_ll_1.log" /tmp/squashfs_ll_1.smoke.log
+        echo "There may be clues in /tmp/squashfs_ll_1.smoke.log"
+        exit 1
     fi
-    sleep 1
-    done
 
-    if ! sq_is_mountpoint "$WORKDIR/mount"; then
-        echo "Image did not mount after 5 seconds."
-        cp "$WORKDIR/squashfs_ll.log" /tmp/squashfs_ll.smoke.log
-        echo "There may be clues in /tmp/squashfs_ll.smoke.log"
+    FIFO_2=$(mktemp -u)
+    mkfifo "$FIFO_2"
+    $SFLL -f $SFLL_EXTRA_ARGS -o notify_pipe="$FIFO_2" "$WORKDIR/squashfs.image" "$WORKDIR/nonexistent_mount" >"$WORKDIR/squashfs_ll_2.log" 2>&1 &
+    # This time the mount command should fail because the mountpoint doesn't exist
+    STATUS=$(head -c1 "$FIFO_2")
+    if [ "$STATUS" != "f" ]; then
+        echo "Image mounted successfully when it should have failed"
+        cp "$WORKDIR/squashfs_ll_2.log" /tmp/squashfs_ll_2.smoke.log
+        echo "There may be clues in /tmp/squashfs_ll_2.smoke.log"
         exit 1
     fi
 


### PR DESCRIPTION
Add the notify_pipe option which allows the user to specify the path to a named pipe. When the mountpoint is ready, a message will be written to this pipe: 's' for success and 'f' for failure. To avoid blocking the fuse process until the pipe is read, a new process is spawned which performs a blocking operation on the pipe. In case of mount failure, no additional process is created and the main process blocks until the pipe is read.

An example of operation is provided below:
```
set -x
FIFO=$(mktemp -u)
mkfifo "$FIFO"
./squashfuse_ll -o notify_pipe="$FIFO" -f /path/to/squashfs/archive /tmp/squash&
STATUS=$(head -c1 "$FIFO")
if [ "$STATUS" = "s" ]; then
	echo "Mountpoint contains:"
	ls /tmp/squash
else
	echo "Mounting squashfuse on /tmp/squash failed"
fi
```

Fixes #49