### PR TITLE
Fix the notification pipe for squashfuse in case of failure

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -106,6 +106,7 @@ endif
 TESTS =
 if SQ_FUSE_TESTS
 TESTS += tests/ll-smoke.sh
+TESTS += tests/notify_test.sh
 if MULTITHREADED
 # I know this test looks backwards, but the default smoke test is multithreaded
 # when threading is enabled. So we additionally run a singlethreaded test in

--- a/fuseprivate.c
+++ b/fuseprivate.c
@@ -79,7 +79,8 @@ int sqfs_usage(char *progname, bool fuse_usage, bool ll_usage) {
 	fprintf(stderr, "\n%s options:\n", progname);
 	fprintf(stderr, "    -o offset=N            offset N bytes into ARCHIVE to mount\n");
 	fprintf(stderr, "    -o subdir=PATH         mount subdirectory PATH of ARCHIVE\n");
-	fprintf(stderr, "    -o notify_pipe=PATH    named pipe that will receive 's' (success) or 'f' (failure) when the mountpoint is ready\n");
+	fprintf(stderr, "    -o notify_pipe=PATH    named pipe that will receive 's' (success)\n"
+			"                           or 'f' (failure) when the mountpoint is ready\n");
 	if (ll_usage) {
 		fprintf(stderr, "    -o timeout=N           idle N seconds for automatic unmount\n");
 		fprintf(stderr, "    -o uid=N               set file owner to uid N\n");

--- a/hl.c
+++ b/hl.c
@@ -343,19 +343,21 @@ int main(int argc, char *argv[]) {
 	}
 	
 	hl = sqfs_hl_open(opts.image, opts.offset, opts.subdir);
-	if (!hl)
-		return -1;
+	if (!hl) {
+		ret = -1;
+		goto out;
+	}
 
 	hl->fs.notify_pipe = opts.notify_pipe;
 	
 	fuse_opt_add_arg(&args, "-s"); /* single threaded */
 	ret = fuse_main(args.argc, args.argv, &sqfs_hl_ops, hl);
+out:
 	if (ret) {
-		if (hl->fs.notify_pipe) {
-			notify_mount_ready(hl->fs.notify_pipe, NOTIFY_FAILURE);
+		if (opts.notify_pipe) {
+			notify_mount_ready(opts.notify_pipe, NOTIFY_FAILURE);
 		}
 	}
-out:
 	fuse_opt_free_args(&args);
 	return ret;
 }

--- a/tests/lib.sh.in
+++ b/tests/lib.sh.in
@@ -1,3 +1,18 @@
+sq_umount() {
+    case @build_os@ in
+        linux*)
+            @sq_fusermount@ -u $1
+            ;;
+        *)
+            umount $1
+            ;;
+    esac
+}
+
+sq_is_mountpoint() {
+    mount | grep -q "$1"
+}
+
 find_compressors() {
   touch "$WORKDIR/comp_input"
   compressors=

--- a/tests/ll-smoke.sh.in
+++ b/tests/ll-smoke.sh.in
@@ -14,21 +14,6 @@ set -e
 
 WORKDIR=$(mktemp -d)
 
-sq_umount() {
-    case @build_os@ in
-        linux*)
-            @sq_fusermount@ -u $1
-            ;;
-        *)
-            umount $1
-            ;;
-    esac
-}
-
-sq_is_mountpoint() {
-    mount | grep -q "$1"
-}
-
 cleanup() {
     set +e # Don't care about errors here.
     if [ -n "$WORKDIR" ]; then
@@ -62,25 +47,25 @@ for comp in $compressors; do
     echo "Mounting squashfs image..."
     FIFO_1=$(mktemp -u)
     mkfifo "$FIFO_1"
-    $SFLL -f $SFLL_EXTRA_ARGS -o notify_pipe="$FIFO_1" "$WORKDIR/squashfs.image" "$WORKDIR/mount" >"$WORKDIR/squashfs_ll_1.log" 2>&1 &
+    $SFLL -f $SFLL_EXTRA_ARGS -o notify_pipe="$FIFO_1" "$WORKDIR/squashfs.image" "$WORKDIR/mount" >"$WORKDIR/squahfs_ll.log" 2>&1 &
     # Wait for the archive to be mounted. TSAN builds can take some time to mount.
     STATUS=$(head -c1 "$FIFO_1")
     if [ "$STATUS" != "s" ]; then
         echo "Image did not mount successfully"
-        cp "$WORKDIR/squashfs_ll_1.log" /tmp/squashfs_ll_1.smoke.log
-        echo "There may be clues in /tmp/squashfs_ll_1.smoke.log"
+        cp "$WORKDIR/squahfs_ll.log" /tmp/squahfs_ll.smoke.log
+        echo "There may be clues in /tmp/squahfs_ll.smoke.log"
         exit 1
     fi
 
     FIFO_2=$(mktemp -u)
     mkfifo "$FIFO_2"
-    $SFLL -f $SFLL_EXTRA_ARGS -o notify_pipe="$FIFO_2" "$WORKDIR/squashfs.image" "$WORKDIR/nonexistent_mount" >"$WORKDIR/squashfs_ll_2.log" 2>&1 &
+    $SFLL -f $SFLL_EXTRA_ARGS -o notify_pipe="$FIFO_2" "$WORKDIR/squashfs.image" "$WORKDIR/nonexistent_mount" >"$WORKDIR/squahfs_ll.log" 2>&1 &
     # This time the mount command should fail because the mountpoint doesn't exist
     STATUS=$(head -c1 "$FIFO_2")
     if [ "$STATUS" != "f" ]; then
         echo "Image mounted successfully when it should have failed"
-        cp "$WORKDIR/squashfs_ll_2.log" /tmp/squashfs_ll_2.smoke.log
-        echo "There may be clues in /tmp/squashfs_ll_2.smoke.log"
+        cp "$WORKDIR/squahfs_ll.log" /tmp/squahfs_ll.smoke.log
+        echo "There may be clues in /tmp/squahfs_ll.smoke.log"
         exit 1
     fi
 

--- a/tests/notify_test.sh
+++ b/tests/notify_test.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+. "tests/lib.sh"
+
+# Test the notification pipe mechanism: it should receive 's' on success and 'f' on failure
+
+trap cleanup EXIT
+set -e
+WORKDIR=$(mktemp -d)
+
+cleanup() {
+    set +e # Don't care about errors here.
+    if [ -n "$WORKDIR" ]; then
+        if [ -n "$SQ_SAVE_LOGS" ]; then
+            cp "$WORKDIR/squashfs.log" "$SQ_SAVE_LOGS" || true
+        fi
+        if sq_is_mountpoint "$WORKDIR/mount"; then
+            sq_umount "$WORKDIR/mount"
+        fi
+        rm -rf "$WORKDIR"
+    fi
+}
+echo "Generating random test files..."
+mkdir -p "$WORKDIR/source"
+mkdir -p "$WORKDIR/mount"
+head -c 17000 /dev/urandom >"$WORKDIR/source/rand1"
+
+echo "Building squashfs image..."
+mksquashfs "$WORKDIR/source" "$WORKDIR/squashfs.image" -no-progress
+
+FIFO=$(mktemp -u)
+mkfifo "$FIFO"
+
+for prog in ./squashfuse ./squashfuse_ll; do
+  echo "Mounting squashfs archive with $prog"
+  # Check that 's' is sent to the notification pipe in case of successful mount
+  $prog -f -o notify_pipe="$FIFO" "$WORKDIR/squashfs.image" "$WORKDIR/mount" >"$WORKDIR/squashfs.log" 2>&1 &
+  STATUS=$(head -c1 "$FIFO")
+  if [ "$STATUS" != "s" ]; then
+    echo "Mounting squashfuse on /tmp/squash failed"
+    exit 1
+  fi
+  sq_umount "$WORKDIR/mount"
+
+  # Check that 'f' is sent to the notification pipe in case of failure
+  $prog -f -o notify_pipe="$FIFO" /dev/null "$WORKDIR/mount" >"$WORKDIR/squashfs.log" 2>&1 &
+  STATUS=$(head -c1 "$FIFO")
+  if [ "$STATUS" != "f" ]; then
+    echo "Mountpoint should have failed"
+    exit 1
+  fi
+done


### PR DESCRIPTION
The following scenario now correctly sends a failure notification to the pipe:
```
$ mkfifo /tmp/notify_pipe
$ cat /tmp/notify_pipe
```
then run squashfuse:
```
$ ./squashfuse -o notify_pipe=/tmp/notify_pipe /dev/null /mnt
```
This fix only applies to squashfuse, squashfuse_ll was behaving as expected.

Fixes #112