### PR TITLE
Update README

### DIFF
--- a/README
+++ b/README
@@ -131,14 +131,16 @@ For example on Ubuntu 16.04:
 
 On macOS, for example:
 
-  $ brew install autoconf automake
+  $ brew install autoconf automake pkg-config libtool lzo xz
   $ glibtoolize --force
   $ aclocal
   $ autoheader
   $ automake --force-missing --add-missing
   $ autoconf
-  $ ./configure
-  $ make
+  $ ./configure --prefix=/Users/me/.local/ \
+        --with-lzo=/usr/local/Cellar/lzo/2.10 \
+        --with-xz=/usr/local/Cellar/xz/5.4.4
+  $ make install
 
 2f. Usage
 ---------


### PR DESCRIPTION
More details for macOS build example.

Needed these days because squashfuse is not available in upstream homebrew core anymore.