### PR TITLE
Fix example + distcheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,11 @@ jobs:
           make check
           diff -u ci/expected-features/${CHECK_FEATURES:-all} ci/features
         if: runner.os != 'macOS'
+      - name: distcheck
+        run: |
+          make distcheck
+        # This is expensive, run just once
+        if: matrix.name == 'Ubuntu'
       - name: test
         run: |
           # On macOS loading the macfuse extension is needed.  This

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
             os: ubuntu-latest
             disable_fuse: "--disable-fuse"
             check_features: demo
+          - name: distcheck
+            os: ubuntu-latest
           - name: Old distro
             os: ubuntu-20.04
           - name: Mac
@@ -46,22 +48,20 @@ jobs:
           brew install autoconf automake libtool pkgconfig squashfs coreutils
           brew install --cask macfuse
         if: runner.os == 'macOS'
-      - name: build
+      - name: configure
         run: |
           ./autogen.sh
           CPPFLAGS="-Werror" ./configure $DISABLE_FUSE
+      - name: build
+        run: |
           make -j2 V=1
+        if: matrix.name != 'distcheck'
       - name: test
         run: |
           make check
           diff -u ci/expected-features/${CHECK_FEATURES:-all} ci/features
-        if: runner.os != 'macOS'
-      - name: distcheck
-        run: |
-          make distcheck
-        # This is expensive, run just once
-        if: matrix.name == 'Ubuntu'
-      - name: test
+        if: runner.os != 'macOS' && matrix.name != 'distcheck'
+      - name: test mac
         run: |
           # On macOS loading the macfuse extension is needed.  This
           # command should load it without rebooting, except System
@@ -73,8 +73,13 @@ jobs:
             diff -u ci/expected-features/${CHECK_FEATURES:-all} ci/features
           fi
         if: runner.os == 'macOS'
+      - name: distcheck
+        run: |
+          make distcheck
+        if: matrix.name == 'distcheck'
       - name: install
         run: sudo make install
+        if: matrix.name != 'distcheck'
       - name: output
         run: |
             cp /tmp/*.log . || true

--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,5 @@ win/Release
 ci/features
 tests/lib.sh
 tests/ll-smoke.sh
+tests/ll-smoke-singlethreaded.sh
 tests/umount-test.sh

--- a/Makefile.am
+++ b/Makefile.am
@@ -126,7 +126,7 @@ if SQ_DEMO_TESTS
 TESTS += tests/ls.sh
 endif
 tests/ll-smoke.sh tests/ls.sh: tests/lib.sh
-
+EXTRA_DIST += tests/ll-smoke-singlethreaded.sh tests/ls.sh tests/notify_test.sh
 
 # Handle generation of swap include files
 CLEANFILES = swap.h.inc swap.c.inc
@@ -134,3 +134,5 @@ EXTRA_DIST += swap.h.inc swap.c.inc
 $(libsquashfuse_convenience_la_OBJECTS): swap.h.inc
 swap.h.inc swap.c.inc: gen_swap.sh squashfs_fs.h Makefile
 	SED="$(SED)" $(srcdir)/gen_swap.sh $(srcdir)/squashfs_fs.h
+
+EXTRA_DIST += ci/expected-features/all ci/expected-features/demo

--- a/README
+++ b/README
@@ -116,9 +116,10 @@ detailed instructions:
 
 For example on Ubuntu 22.04:
 
-  $ sudo apt install pkg-config liblzma-dev libfuse3-dev \
-    automake autoconf libtool fio \
-    zlib1g-dev liblzo2-dev liblzma-dev liblz4-dev libzstd-dev
+  $ sudo apt install gcc make pkg-config libfuse3-dev \
+    zlib1g-dev liblzo2-dev liblzma-dev liblz4-dev libzstd-dev \
+    automake autoconf libtool \
+    fuse3 fio squashfs-tools
   $ ./autogen.sh
   $ ./configure
   $ make -j4

--- a/configure.ac
+++ b/configure.ac
@@ -91,6 +91,7 @@ AS_IF([test "x$sq_tests" = x], [sq_tests=" none"])
 
 AC_SUBST([sq_mksquashfs_compressors])
 AC_CONFIG_FILES([tests/ll-smoke.sh],[chmod +x tests/ll-smoke.sh])
+AC_CONFIG_FILES([tests/ll-smoke-singlethreaded.sh],[chmod +x tests/ll-smoke-singlethreaded.sh])
 AC_CONFIG_FILES([tests/umount-test.sh],[chmod +x tests/umount-test.sh])
 
 

--- a/tests/ll-smoke-singlethreaded.sh.in
+++ b/tests/ll-smoke-singlethreaded.sh.in
@@ -7,4 +7,4 @@
 # the FUSE '-s' commandline option.
 #
 # So we just re-run the normal ll-smoke test with the '-s' option.
-SFLL_EXTRA_ARGS="-s" $(dirname -- $0)/ll-smoke.sh
+SFLL_EXTRA_ARGS="-s" @builddir@/tests/ll-smoke.sh


### PR DESCRIPTION
* Add extra dependencies to README example, it should work now in a docker ubuntu:jammy container
* While testing that this was fixed, noticed that out-of-tree builds and tests from release tarballs are both broken!
   * Added some missing files to the dist tarball
   * Made ll-smoke-singlethreaded aware of where ll-smoke lives, so it can be run out of tree
   * Added a new test to enforce that dist builds are working