### PR TITLE
Do apt-get update before any installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
         uses: actions/checkout@v2
       - name: apt dependencies
         run: > 
+          sudo apt-get update &&
           sudo apt-get install -y automake autoconf libtool pkg-config
           zlib1g-dev liblzo2-dev liblzma-dev liblz4-dev libzstd-dev
           fio


### PR DESCRIPTION
This fixes ci failures seen after merging the last PR into the master branch.