### PR TITLE
Fix 32 bit compile on Fedora 40

### DIFF
--- a/ll.c
+++ b/ll.c
@@ -410,7 +410,12 @@ void sqfs_ll_op_getxattr(fuse_req_t req, fuse_ino_t ino,
 }
 
 void sqfs_ll_op_forget(fuse_req_t req, fuse_ino_t ino,
-		unsigned long nlookup) {
+#ifdef HAVE_FUSE_LL_FORGET_OP_64T
+		uint64_t nlookup
+#else
+		unsigned long nlookup
+#endif
+		) {
 	sqfs_ll_i lli;
 	update_access_time();
 	sqfs_ll_iget(req, &lli, SQFS_FUSE_INODE_NONE);

--- a/ll.h
+++ b/ll.h
@@ -109,7 +109,12 @@ void sqfs_ll_op_getxattr(fuse_req_t req, fuse_ino_t ino,
 		);
 
 void sqfs_ll_op_forget(fuse_req_t req, fuse_ino_t ino,
-		unsigned long nlookup);
+#ifdef HAVE_FUSE_LL_FORGET_OP_64T
+		uint64_t nlookup
+#else
+		unsigned long nlookup
+#endif
+		);
 
 void sqfs_ll_op_init(void *userdata, struct fuse_conn_info *conn);
 

--- a/m4/squashfuse_fuse.m4
+++ b/m4/squashfuse_fuse.m4
@@ -272,6 +272,25 @@ AC_DEFUN([SQ_FUSE_API_VERSION],[
 					[Define if we have two-argument fuse_unmount])
 		])
 
+		AC_CACHE_CHECK([for 64_t third argument to fuse ll forget op],
+				[sq_cv_decl_fuse_forget_64_t],[
+			AC_LINK_IFELSE(
+				[AC_LANG_PROGRAM([
+				#include <fuse.h>
+				#include <fuse_lowlevel.h>],
+					[
+					void f(fuse_req_t, fuse_ino_t, uint64_t);
+					struct fuse_lowlevel_ops flo;
+					flo.forget = f;
+					])],
+				[sq_cv_decl_fuse_forget_64_t=yes],
+				[sq_cv_decl_fuse_forget_64_t=no])
+		])
+		AS_IF([test "x$sq_cv_decl_fuse_forget_64_t" = xyes],[
+			AC_DEFINE([HAVE_FUSE_LL_FORGET_OP_64T],1,
+					[Define if we have uint64_t as type of 3rd arg to ll forget op])
+		])
+
 		AC_CHECK_DECLS([fuse_cmdline_help],,,
 		        [#include <fuse_lowlevel.h>])
 	])


### PR DESCRIPTION
This fixes 32 bit compiles on Fedora 40.  Without it, this compiler error shows:
```
+ make squashfuse_ll
  CC       squashfuse_ll-ll_main.o
ll_main.c: In function ‘main’:
ll_main.c:164:41: error: assignment to ‘void (*)(struct fuse_req *, fuse_ino_t,  uint64_t)’ {aka ‘void (*)(struct fuse_req *, long long unsigned int,  long long unsigned int)’} from incompatible pointer type ‘void (*)(struct fuse_req *, fuse_ino_t,  long unsigned int)’ {aka ‘void (*)(struct fuse_req *, long long unsigned int,  long unsigned int)’} [-Wincompatible-pointer-types]
  164 |         sqfs_ll_ops.forget              = sqfs_ll_op_forget;
      |                                         ^
make: *** [Makefile:1373: squashfuse_ll-ll_main.o] Error 1
```