### PR TITLE
Leave config.h out of dist

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -17,8 +17,9 @@ noinst_LTLIBRARIES =
 
 pkgincludedir = @includedir@/squashfuse
 pkginclude_HEADERS = squashfuse.h squashfs_fs.h \
-	cache.h common.h config.h decompress.h dir.h file.h fs.h stack.h table.h \
+	cache.h common.h decompress.h dir.h file.h fs.h stack.h table.h \
 	traverse.h util.h xattr.h
+nodist_pkginclude_HEADERS = config.h
 pkgconfigdir = @pkgconfigdir@
 pkgconfig_DATA 	= squashfuse.pc
 


### PR DESCRIPTION
Fixes #129 

* Verified that `make dist` no longer includes config.h
* Verified that `make distcheck` still works
* Verified that `make install` still installs config.h