### PR TITLE
Allow handling broken directory offsets

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -116,6 +116,12 @@ AC_ARG_ENABLE([sigterm-handler],
     ])
 AM_CONDITIONAL([SIGTERM_HANDLER], [test x$enable_sigterm_handler = xyes])
 
+AC_ARG_ENABLE([broken-directory-offsets],
+	AS_HELP_STRING([--enable-broken-directory-offsets], [handle broken directory offsets, for implementations like FUSE-T]),
+	[broken_dir_offsets="yes"])
+AS_IF([test x$broken_dir_offsets = xyes],
+	[AC_DEFINE(SQFS_BROKEN_DIR_OFFSETS, 1, [Handle broken directory offsets])])
+
 AC_SUBST([sq_decompressors])
 AC_SUBST([sq_high_level])
 AC_SUBST([sq_low_level])

--- a/hl.c
+++ b/hl.c
@@ -142,13 +142,20 @@ static int sqfs_hl_op_readdir(const char *path, void *buf,
 	sqfs_hl_lookup(&fs, NULL, NULL);
 	inode = (sqfs_inode*)(intptr_t)fi->fh;
 		
+#ifdef SQFS_BROKEN_DIR_OFFSETS
+	offset = 0;
+#endif
 	if (sqfs_dir_open(fs, inode, &dir, offset))
 		return -EINVAL;
 	
 	memset(&st, 0, sizeof(st));
 	sqfs_dentry_init(&entry, namebuf);
 	while (sqfs_dir_next(fs, &dir, &entry, &err)) {
+#ifdef SQFS_BROKEN_DIR_OFFSETS
+		sqfs_off_t doff = 0;
+#else
 		sqfs_off_t doff = sqfs_dentry_next_offset(&entry);
+#endif
 		st.st_mode = sqfs_dentry_mode(&entry);
 		if (filler(buf, sqfs_dentry_name(&entry), &st, doff
 #if FUSE_USE_VERSION >= 30


### PR DESCRIPTION
FUSE-T is an implementation of FUSE for macOS, which is becoming popular. But squashfuse doesn't work with FUSE-T, erroring when directories are listed. This is due to FUSE-T supplying improper `offset` values to the FUSE readdir ops.

Now, squashfuse can be built with `--enable-broken-directory-offsets` to fix this behavior.

FUSE readdir ops (both high-level and low-level) return lists of directory entries. Each returned entry has an `off` field, whose value is arbitrary, entirely up to the filesystem. Subsequent calls to readdir can supply one of these offsets to continue reading from the middle of a directory.

In squashfuse, we return as `off` an offset into the squashfs internal directory entries. This lets us quickly jump to the right entry using the squashfs directory index, without reading all intermediate entries.

However, FUSE-T does NOT supply a previously-returned offset to readdir. Instead, it uses the size of the buffer that squashfuse returned from readdir. This is entirely outside of the FUSE spec! When FUSE-T does this, squashfuse can't find the supplied offset, and errors.

The fix is to simply not attempt to jump to the correct entry. When squashfuse is built with broken-directory-offsets enabled, we just read every entry from the start of the directory, until our buffer size reaches the provided offset. This is inefficient, but probably ok for reasonable directory sizes.

Unfortunately, we need the user to provide a `configure` argument to trigger this fix. FUSE-T attempts to exactly mirror the FUSE headers and API, so there doesn't seem to be a way to detect this behavior. Even at run-time, FUSE-T could provide a wrong offset that happens to be a valid value, so we can't just look for seek failures.