### PR TITLE
Add "." and ".." in directory listings

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,7 +3,7 @@ env:
 
 freebsd_task:
   freebsd_instance:
-    image_family: freebsd-14-0
+    image_family: freebsd-14-2
   setup_script:
     - pkg install -y autoconf automake libtool pkgconf fusefs-libs
     - pkg install -y lzo2 liblz4 zstd


### PR DESCRIPTION
This is a first attempt at
- fixes #133

I'm sure it is incomplete but it does work to make `ls -a` show `.` and `..` files.

@vasi Can you give me some hints on what else is needed?  I didn't know what to fill in the `inode` and `inode_number` fields but it doesn't seem to make a difference for `ls -a` and `ls -al`.  Also I would think that some of the other functions in dir.c that deal with offsets will need some changes but I don't really know what changes.

I came up with the idea of adding fake offset indexes from the corresponding [squashfs kernel code](https://github.com/torvalds/linux/blob/v6.11/fs/squashfs/dir.c#L116).