### PR TITLE
Fix macOS CI failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: apt dependencies
         run: > 
           sudo apt-get update &&
-          sudo apt-get install -y automake autoconf libtool pkg-config
+          sudo apt-get install -y automake autoconf libtool pkgconf
           zlib1g-dev liblzo2-dev liblzma-dev liblz4-dev libzstd-dev
           fio
         if: runner.os == 'Linux'
@@ -46,7 +46,11 @@ jobs:
         env:
           HOMEBREW_NO_AUTO_UPDATE: 1
         run: |
-          brew install autoconf automake libtool pkgconfig squashfs coreutils
+          # Keep these until https://github.com/Homebrew/homebrew-core/pull/194885 is available by default
+          brew remove pkg-config
+          brew update
+
+          brew install autoconf automake libtool pkgconf squashfs coreutils
           brew install --cask macfuse
         if: runner.os == 'macOS'
       - name: configure

--- a/autogen.sh
+++ b/autogen.sh
@@ -17,9 +17,11 @@ if libtoolize --version > /dev/null 2>&1; then : ; else
   fi
 fi
 
-if pkg-config --version > /dev/null 2>&1; then : ; else
-  echo "Missing pkg-config"
-  exit 1
+if pkgconf --version > /dev/null 2>&1; then : ; else
+  if pkg-config --version > /dev/null 2>&1; then : ; else
+    echo "Missing pkg-config"
+    exit 1
+  fi
 fi
 
 exec autoreconf -i


### PR DESCRIPTION
We're getting errors because of homebrew's migration from pkg-config to pkgconf: https://github.com/Homebrew/homebrew-core/pull/194885

To solve:
* Enable pkgconf in general, we'd prefer it to the ancient pkg-config
* For now, just wipe pkg-config from the macos running, and then update so we get the new pkgconf version that replaces it
* Eventually, Github will upgrade their runner so it has pkgconf, and we'll get to remove the brew remove/update

Error:

```
==> Pouring pkgconf--2.3.0_1.arm64_sonoma.bottle.tar.gz
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /opt/homebrew
Could not symlink bin/pkg-config
Target /opt/homebrew/bin/pkg-config
is a symlink belonging to pkg-config@0.29.2. You can unlink it:
  brew unlink pkg-config@0.29.2

To force the link and overwrite all conflicting files:
  brew link --overwrite pkgconf

To list all files that would be deleted:
  brew link --overwrite pkgconf --dry-run
```