### PR TITLE
fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
         shell: powershell
         run: choco install -y squashfs 
       - name: setup msbuild
-        uses: microsoft/setup-msbuild@v1.0.2
+        uses: microsoft/setup-msbuild@v2
       - name: checkout
         uses: actions/checkout@v2
       - name: generate header

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           - name: Old distro
             os: ubuntu-22.04
           - name: Mac
-            os: macos-latest
+            os: macos-15
     env:
       CHECK_FEATURES: ${{ matrix.check_features }}
       DISABLE_FUSE: ${{ matrix.disable_fuse }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,17 +15,22 @@ jobs:
             os: ubuntu-latest
           - name: No FUSE
             os: ubuntu-latest
-            disable_fuse: "--disable-fuse"
+            configure_args: "--disable-fuse"
             check_features: demo
           - name: distcheck
             os: ubuntu-latest
           - name: Old distro
             os: ubuntu-22.04
-          - name: Mac
+          - name: macFUSE
             os: macos-15
+          - name: FUSE-T
+            os: macos-15
+            configure_vars: 'LDFLAGS=-Wl,-rpath,/usr/local/lib'
+            configure_args: '--with-fuse-soname=fuse-t'
     env:
       CHECK_FEATURES: ${{ matrix.check_features }}
-      DISABLE_FUSE: ${{ matrix.disable_fuse }}
+      CONFIGURE_VARS: ${{ matrix.configure_vars }}
+      CONFIGURE_ARGS: ${{ matrix.configure_args }}
     steps:
       - name: checkout
         uses: actions/checkout@v2
@@ -34,7 +39,7 @@ jobs:
           sudo apt-get update &&
           sudo apt-get install -y automake autoconf libtool pkgconf
           zlib1g-dev liblzo2-dev liblzma-dev liblz4-dev libzstd-dev
-          fio
+          squashfs-tools fio
         if: runner.os == 'Linux'
       - name: apt fuse 2
         run: sudo apt-get install -y libfuse-dev fuse
@@ -50,13 +55,21 @@ jobs:
           brew remove pkg-config
           brew update
 
-          brew install autoconf automake libtool pkgconf squashfs coreutils
-          brew install --cask macfuse
+          brew install autoconf automake libtool pkgconf squashfs coreutils lzo lz4 zstd
         if: runner.os == 'macOS'
+      - name: macfuse
+        run: brew install --cask macfuse
+        if: matrix.name == 'macFUSE'
+      - name: fuse-t
+        run: |
+          sudo mkdir -p /usr/local/include # no symlink to headers is placed here unless it exists
+          brew tap macos-fuse-t/homebrew-cask
+          brew install fuse-t
+        if: matrix.name == 'FUSE-T'
       - name: configure
         run: |
           ./autogen.sh
-          CPPFLAGS="-Werror" ./configure $DISABLE_FUSE
+          env CPPFLAGS="-Werror" $CONFIGURE_VARS ./configure $CONFIGURE_ARGS
       - name: build
         run: |
           make -j2 V=1
@@ -65,19 +78,8 @@ jobs:
         run: |
           make check
           diff -u ci/expected-features/${CHECK_FEATURES:-all} ci/features
-        if: runner.os != 'macOS' && matrix.name != 'distcheck'
-      - name: test mac
-        run: |
-          # On macOS loading the macfuse extension is needed.  This
-          # command should load it without rebooting, except System
-          # Integrity Protection disallows it, so the tests get skipped
-          # there.  This command came from
-          #   https://github.com/actions/runner-images/issues/4731
-          if sudo kextload /Library/Filesystems/macfuse.fs/Contents/Extensions/$(sw_vers -productVersion|cut -d. -f1)/macfuse.kext; then
-            make check
-            diff -u ci/expected-features/${CHECK_FEATURES:-all} ci/features
-          fi
-        if: runner.os == 'macOS'
+        # Can't accept security warning to allow macFUSE kext to work in CI
+        if: matrix.name != 'macFUSE' && matrix.name != 'distcheck'
       - name: distcheck
         run: |
           make distcheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,8 @@ jobs:
             os: macos-15
           - name: FUSE-T
             os: macos-15
-            ldflags: '-Wl,-rpath,/usr/local/lib'
-            configure_args: '--with-fuse-soname=fuse-t'
     env:
       CHECK_FEATURES: ${{ matrix.check_features }}
-      LDFLAGS: ${{ matrix.ldflags }}
       CONFIGURE_ARGS: ${{ matrix.configure_args }}
     steps:
       - name: checkout
@@ -52,22 +49,22 @@ jobs:
           HOMEBREW_NO_AUTO_UPDATE: 1
         run: |
           brew install autoconf automake libtool squashfs coreutils
-          echo "BREW_LDFLAGS=-L$(brew --prefix)/lib" >> $GITHUB_ENV
-          echo "BREW_CPPFLAGS=-I$(brew --prefix)/include" >> $GITHUB_ENV
+          echo "LDFLAGS=-L$(brew --prefix)/lib" >> $GITHUB_ENV
+          echo "CPPFLAGS=-I$(brew --prefix)/include" >> $GITHUB_ENV
         if: runner.os == 'macOS'
       - name: macfuse
         run: brew install --cask macfuse
         if: matrix.name == 'macFUSE'
       - name: fuse-t
         run: |
-          sudo mkdir -p /usr/local/include # no symlink to headers is placed here unless it exists
+          find /usr/local -ls
           brew tap macos-fuse-t/homebrew-cask
           brew install fuse-t
         if: matrix.name == 'FUSE-T'
       - name: configure
         run: |
           ./autogen.sh
-          env CPPFLAGS="-Werror $BREW_CPPFLAGS" LDFLAGS="$LDFLAGS $BREW_LDFLAGS" ./configure $CONFIGURE_ARGS
+          env CPPFLAGS="-Werror $CPPFLAGS" ./configure $CONFIGURE_ARGS
       - name: check discovered features
         run: diff -u ci/expected-features/${CHECK_FEATURES:-all} ci/features
         if: matrix.name != 'distcheck'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           - name: distcheck
             os: ubuntu-latest
           - name: Old distro
-            os: ubuntu-20.04
+            os: ubuntu-22.04
           - name: Mac
             os: macos-latest
     env:
@@ -38,7 +38,7 @@ jobs:
         if: runner.os == 'Linux'
       - name: apt fuse 2
         run: sudo apt-get install -y libfuse-dev fuse
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-22.04'
       - name: apt fuse 3
         run: sudo apt-get install -y libfuse3-dev fuse3
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,11 @@ jobs:
             os: macos-15
           - name: FUSE-T
             os: macos-15
-            configure_vars: 'LDFLAGS=-Wl,-rpath,/usr/local/lib'
+            ldflags: '-Wl,-rpath,/usr/local/lib'
             configure_args: '--with-fuse-soname=fuse-t'
     env:
       CHECK_FEATURES: ${{ matrix.check_features }}
-      CONFIGURE_VARS: ${{ matrix.configure_vars }}
+      LDFLAGS: ${{ matrix.ldflags }}
       CONFIGURE_ARGS: ${{ matrix.configure_args }}
     steps:
       - name: checkout
@@ -51,11 +51,9 @@ jobs:
         env:
           HOMEBREW_NO_AUTO_UPDATE: 1
         run: |
-          # Keep these until https://github.com/Homebrew/homebrew-core/pull/194885 is available by default
-          brew remove pkg-config
-          brew update
-
-          brew install autoconf automake libtool pkgconf squashfs coreutils lzo lz4 zstd
+          brew install autoconf automake libtool squashfs coreutils
+          echo "BREW_LDFLAGS=-L$(brew --prefix)/lib" >> $GITHUB_ENV
+          echo "BREW_CPPFLAGS=-I$(brew --prefix)/include" >> $GITHUB_ENV
         if: runner.os == 'macOS'
       - name: macfuse
         run: brew install --cask macfuse
@@ -69,20 +67,19 @@ jobs:
       - name: configure
         run: |
           ./autogen.sh
-          env CPPFLAGS="-Werror" $CONFIGURE_VARS ./configure $CONFIGURE_ARGS
+          env CPPFLAGS="-Werror $BREW_CPPFLAGS" LDFLAGS="$LDFLAGS $BREW_LDFLAGS" ./configure $CONFIGURE_ARGS
+      - name: check discovered features
+        run: diff -u ci/expected-features/${CHECK_FEATURES:-all} ci/features
+        if: matrix.name != 'distcheck'
       - name: build
-        run: |
-          make -j2 V=1
+        run: make -j2 V=1
         if: matrix.name != 'distcheck'
       - name: test
-        run: |
-          make check
-          diff -u ci/expected-features/${CHECK_FEATURES:-all} ci/features
+        run: make check
         # Can't accept security warning to allow macFUSE kext to work in CI
         if: matrix.name != 'macFUSE' && matrix.name != 'distcheck'
       - name: distcheck
-        run: |
-          make distcheck
+        run: make distcheck
         if: matrix.name == 'distcheck'
       - name: install
         run: sudo make install

--- a/Makefile.am
+++ b/Makefile.am
@@ -33,7 +33,7 @@ libsquashfuse_convenience_la_SOURCES = swap.c cache.c table.c dir.c file.c fs.c 
 	util.h fs.h
 libsquashfuse_convenience_la_CPPFLAGS = $(ZLIB_CPPFLAGS) $(XZ_CPPFLAGS) $(LZO_CPPFLAGS) \
 	$(LZ4_CPPFLAGS) $(ZSTD_CPPFLAGS) $(FUSE_CPPFLAGS)
-libsquashfuse_convenience_la_LIBADD = $(COMPRESSION_LIBS) $(FUSE_LIBS)
+libsquashfuse_convenience_la_LIBADD = $(COMPRESSION_LIBS)
 
 # Main library: libsquashfuse
 lib_LTLIBRARIES += libsquashfuse.la

--- a/configure.ac
+++ b/configure.ac
@@ -46,6 +46,7 @@ AS_IF([test "x$sq_decompressors" = x],
 # FUSE
 SQ_FUSE_API
 AS_IF([test "x$sq_fuse_found" = xyes],[
+	SQ_FUSE_API_MACFUSE_EXTENSIONS
 	SQ_FUSE_API_LOWLEVEL
 	SQ_FUSE_API_VERSION
 	SQ_FUSE_API_XATTR_POSITION

--- a/m4/squashfuse_fuse.m4
+++ b/m4/squashfuse_fuse.m4
@@ -163,6 +163,18 @@ AC_DEFUN([SQ_FIND_FUSE],[
 			[:])
 		SQ_KEEP_FLAGS([FUSE],[$sq_fuse_found])
 	])
+	# Use pkgconfig to look for fuse-t
+	AS_IF([test "x$sq_fuse_found" = xyes],,[
+        AC_DEFINE([FUSE_USE_VERSION], [26], [Version of FUSE API to use])
+		SQ_SAVE_FLAGS
+		SQ_PKG([fuse_t],[fuse-t],[
+			# FUSE-T bug can mis-install header path: https://github.com/macos-fuse-t/fuse-t/issues/77
+			CPPFLAGS="$CPPFLAGS -D_FILE_OFFSET_BITS=64 -I/Library/Frameworks/fuse_t.framework/Headers"
+			SQ_TRY_FUSE([fuse-t],[sq_fuse_found=yes],
+	        [AC_MSG_FAILURE([Can't find fuse-t with pkgconfig])])
+		], [:])
+		SQ_KEEP_FLAGS([FUSE],[$sq_fuse_found])
+	])
 	
 	# Default search locations
 	AS_IF([test "x$sq_cv_lib_fuse_LIBS" = x],[SQ_SEARCH_FUSE_DIRS],[

--- a/m4/squashfuse_fuse.m4
+++ b/m4/squashfuse_fuse.m4
@@ -322,3 +322,35 @@ AC_DEFUN([SQ_FUSE_API_XATTR_POSITION],[
 	
 	SQ_RESTORE_FLAGS
 ])
+
+# SQ_FUSE_API_MACFUSE_EXTENSIONS
+#
+# Check if we need to disable macFUSE extensions
+AC_DEFUN([SQ_FUSE_API_MACFUSE_EXTENSIONS],[
+	AC_DEFUN([SQ_FUSE_API_MACFUSE_EXTENSIONS_SOURCE],[
+		AC_LANG_PROGRAM([#include <fuse.h>],[
+			struct fuse_operations ops;
+			int (*getattr_func)(const char*, struct stat*, struct fuse_file_info*);
+			ops.getattr = getattr_func;
+	])])
+
+	AC_CACHE_CHECK([if we need to disable macFUSE extensions],
+		[sq_cv_decl_fuse_macfuse_extensions],[
+		SQ_SAVE_FLAGS
+		LIBS="$LIBS $FUSE_LIBS"
+		CPPFLAGS="$CPPFLAGS $FUSE_CPPFLAGS"
+		AC_COMPILE_IFELSE([SQ_FUSE_API_MACFUSE_EXTENSIONS_SOURCE],
+			[sq_cv_decl_fuse_macfuse_extensions=no],
+			[
+				CPPFLAGS="$CPPFLAGS -DFUSE_DARWIN_ENABLE_EXTENSIONS=0"
+				AC_COMPILE_IFELSE([SQ_FUSE_API_MACFUSE_EXTENSIONS_SOURCE],
+					[sq_cv_decl_fuse_macfuse_extensions=yes],
+					[sq_cv_decl_fuse_macfuse_extensions=no])
+			])
+		SQ_RESTORE_FLAGS
+	])
+
+	AS_IF([test "x$sq_cv_decl_fuse_macfuse_extensions" = xyes],[
+		CPPFLAGS="$CPPFLAGS -DFUSE_DARWIN_ENABLE_EXTENSIONS=0"
+	])
+])

--- a/tests/lib.sh.in
+++ b/tests/lib.sh.in
@@ -28,3 +28,16 @@ find_compressors() {
   fi
   echo "Found compressors:$compressors"
 }
+
+sq_skip_notify() {
+  case @build_os@ in
+    darwin*)
+      if otool -L ./squashfuse | grep -q fuse-t; then
+        echo "yes"
+        return 0
+      fi
+    ;;
+  esac
+  echo "no"
+  return 1
+}

--- a/tests/ll-smoke.sh.in
+++ b/tests/ll-smoke.sh.in
@@ -11,18 +11,6 @@ IDLE_TIMEOUT=5
 
 trap cleanup EXIT
 set -e
-
-test_nonexistent_mountpoint=yes
-test_idle_timeout=yes
-case "$OSTYPE" in
-    darwin*)
-      # macOS may auto-create mountpoints, weird!
-      test_nonexistent_mountpoint=no
-      # macOS background processes poke around in a filesystem, can inhibit timeout
-      test_idle_timeout=no
-      ;;
-esac
-
 WORKDIR=$(mktemp -d)
 
 cleanup() {
@@ -37,6 +25,19 @@ cleanup() {
         rm -rf "$WORKDIR"
     fi
 }
+
+test_nonexistent_mountpoint=yes
+test_idle_timeout=yes
+wait_sleeping=$(sq_skip_notify)
+case "$OSTYPE" in
+    darwin*)
+        # macOS may auto-create mountpoints, weird!
+        test_nonexistent_mountpoint=no
+
+        # macOS background processes can inhibit timeout
+        test_idle_timeout=no
+    ;;
+esac
 
 find_compressors
 
@@ -60,6 +61,9 @@ for comp in $compressors; do
     mkfifo "$FIFO_1"
     $SFLL -f $SFLL_EXTRA_ARGS -o notify_pipe="$FIFO_1" "$WORKDIR/squashfs.image" "$WORKDIR/mount" >"$WORKDIR/squashfs_ll.log" 2>&1 &
     # Wait for the archive to be mounted. TSAN builds can take some time to mount.
+    if [ "x$wait_sleeping" = xyes ]; then
+        sleep 5
+    fi
     STATUS=$(head -c1 "$FIFO_1")
     if [ "$STATUS" != "s" ]; then
         echo "Image did not mount successfully"
@@ -150,7 +154,7 @@ for comp in $compressors; do
     sq_umount "$WORKDIR/mount"
 
     # Only test timeouts once, it takes a long time
-    if [ "x$test_idle_timeout" = yes -a -z "$did_timeout" ]; then
+    if [ "x$test_idle_timeout" = xyes -a -z "$did_timeout" ]; then
         echo "Remounting with idle unmount option..."
         $SFLL $SFLL_EXTRA_ARGS -otimeout=$IDLE_TIMEOUT "$WORKDIR/squashfs.image" "$WORKDIR/mount"
         if ! sq_is_mountpoint "$WORKDIR/mount"; then

--- a/tests/ll-smoke.sh.in
+++ b/tests/ll-smoke.sh.in
@@ -58,20 +58,20 @@ for comp in $compressors; do
     echo "Mounting squashfs image..."
     FIFO_1=$(mktemp -u)
     mkfifo "$FIFO_1"
-    $SFLL -f $SFLL_EXTRA_ARGS -o notify_pipe="$FIFO_1" "$WORKDIR/squashfs.image" "$WORKDIR/mount" >"$WORKDIR/squahfs_ll.log" 2>&1 &
+    $SFLL -f $SFLL_EXTRA_ARGS -o notify_pipe="$FIFO_1" "$WORKDIR/squashfs.image" "$WORKDIR/mount" >"$WORKDIR/squashfs_ll.log" 2>&1 &
     # Wait for the archive to be mounted. TSAN builds can take some time to mount.
     STATUS=$(head -c1 "$FIFO_1")
     if [ "$STATUS" != "s" ]; then
         echo "Image did not mount successfully"
-        cp "$WORKDIR/squahfs_ll.log" /tmp/squahfs_ll.smoke.log
-        echo "There may be clues in /tmp/squahfs_ll.smoke.log"
+        cp "$WORKDIR/squashfs_ll.log" /tmp/squashfs_ll.smoke.log
+        echo "There may be clues in /tmp/squashfs_ll.smoke.log"
         exit 1
     fi
 
     if [ "x$test_nonexistent_mountpoint" = xyes ]; then
         FIFO_2=$(mktemp -u)
         mkfifo "$FIFO_2"
-        $SFLL -f $SFLL_EXTRA_ARGS -o notify_pipe="$FIFO_2" "$WORKDIR/squashfs.image" "$WORKDIR/nonexistent_mount" >"$WORKDIR/squahfs_ll.log" 2>&1 &
+        $SFLL -f $SFLL_EXTRA_ARGS -o notify_pipe="$FIFO_2" "$WORKDIR/squashfs.image" "$WORKDIR/nonexistent_mount" >"$WORKDIR/squashfs_ll.log" 2>&1 &
         # This time the mount command should fail because the mountpoint doesn't exist
         STATUS=$(head -c1 "$FIFO_2")
         if [ "$STATUS" != "f" ]; then

--- a/tests/ll-smoke.sh.in
+++ b/tests/ll-smoke.sh.in
@@ -12,6 +12,17 @@ IDLE_TIMEOUT=5
 trap cleanup EXIT
 set -e
 
+test_nonexistent_mountpoint=yes
+test_idle_timeout=yes
+case "$OSTYPE" in
+    darwin*)
+      # macOS may auto-create mountpoints, weird!
+      test_nonexistent_mountpoint=no
+      # macOS background processes poke around in a filesystem, can inhibit timeout
+      test_idle_timeout=no
+      ;;
+esac
+
 WORKDIR=$(mktemp -d)
 
 cleanup() {
@@ -57,16 +68,18 @@ for comp in $compressors; do
         exit 1
     fi
 
-    FIFO_2=$(mktemp -u)
-    mkfifo "$FIFO_2"
-    $SFLL -f $SFLL_EXTRA_ARGS -o notify_pipe="$FIFO_2" "$WORKDIR/squashfs.image" "$WORKDIR/nonexistent_mount" >"$WORKDIR/squahfs_ll.log" 2>&1 &
-    # This time the mount command should fail because the mountpoint doesn't exist
-    STATUS=$(head -c1 "$FIFO_2")
-    if [ "$STATUS" != "f" ]; then
-        echo "Image mounted successfully when it should have failed"
-        cp "$WORKDIR/squahfs_ll.log" /tmp/squahfs_ll.smoke.log
-        echo "There may be clues in /tmp/squahfs_ll.smoke.log"
-        exit 1
+    if [ "x$test_nonexistent_mountpoint" = xyes ]; then
+        FIFO_2=$(mktemp -u)
+        mkfifo "$FIFO_2"
+        $SFLL -f $SFLL_EXTRA_ARGS -o notify_pipe="$FIFO_2" "$WORKDIR/squashfs.image" "$WORKDIR/nonexistent_mount" >"$WORKDIR/squahfs_ll.log" 2>&1 &
+        # This time the mount command should fail because the mountpoint doesn't exist
+        STATUS=$(head -c1 "$FIFO_2")
+        if [ "$STATUS" != "f" ]; then
+            echo "Image mounted successfully when it should have failed"
+            cp "$WORKDIR/squashfs_ll.log" /tmp/squashfs_ll.smoke.log
+            echo "There may be clues in /tmp/squashfs_ll.smoke.log"
+            exit 1
+        fi
     fi
 
     if command -v fio >/dev/null; then
@@ -137,7 +150,7 @@ for comp in $compressors; do
     sq_umount "$WORKDIR/mount"
 
     # Only test timeouts once, it takes a long time
-    if [ -z "$did_timeout" ]; then
+    if [ "x$test_idle_timeout" = yes -a -z "$did_timeout" ]; then
         echo "Remounting with idle unmount option..."
         $SFLL $SFLL_EXTRA_ARGS -otimeout=$IDLE_TIMEOUT "$WORKDIR/squashfs.image" "$WORKDIR/mount"
         if ! sq_is_mountpoint "$WORKDIR/mount"; then

--- a/tests/ll-smoke.sh.in
+++ b/tests/ll-smoke.sh.in
@@ -28,7 +28,7 @@ cleanup() {
 
 test_nonexistent_mountpoint=yes
 test_idle_timeout=yes
-wait_sleeping=$(sq_skip_notify)
+wait_sleeping=$(sq_skip_notify || true)
 case "$OSTYPE" in
     darwin*)
         # macOS may auto-create mountpoints, weird!

--- a/tests/notify_test.sh
+++ b/tests/notify_test.sh
@@ -20,6 +20,12 @@ cleanup() {
         rm -rf "$WORKDIR"
     fi
 }
+
+if sq_skip_notify >/dev/null; then
+  echo exit
+  exit 77
+fi
+
 echo "Generating random test files..."
 mkdir -p "$WORKDIR/source"
 mkdir -p "$WORKDIR/mount"


### PR DESCRIPTION
CI got a bit out of control, this should fix many issues:

* A step in the Windows build was deprecated, move to a new version
* Ubuntu 20.04 runner is retired, move to 22.04
* Builds are mysteriously stalling on macOS 14, just move to macOS 15 where it appears to work
* Newer versions of macFUSE have some weird non-API-compatible extensions, detect this in autoconf and turn them off.
* The macFUSE build actually can run tests locally, even if not in CI! Just turn off some parts of the tests that are broken:  mounts may succeed on nonexistent mountpoints, and idle timeout doesn't appear to work consistently.
* Fix some typos in the smoke-test script
* Since macFUSE can't run tests in CI, get FUSE-T working instead for tests on macOS
* Remove an old workaround we needed due to a pkg-config -> pkgconf transition in homebrew
* Make FUSE-T detection work automatically