### PR TITLE
Add private dependencies to squashfuse.pc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -35,11 +35,11 @@ SQ_CHECK_DECL_ENOATTR([:])
 SQ_CHECK_DECL_SYMLINK
 
 # Decompression
-SQ_CHECK_DECOMPRESS([ZLIB],[z],[uncompress],[zlib.h],,[gzip])
+SQ_CHECK_DECOMPRESS([ZLIB],[z],[uncompress],[zlib.h],[zlib],[gzip])
 SQ_CHECK_DECOMPRESS([XZ],[lzma],[lzma_stream_buffer_decode],[lzma.h],[liblzma],[xz])
-SQ_CHECK_DECOMPRESS([LZO],[lzo2],[lzo1x_decompress_safe],[lzo/lzo1x.h],,[lzo])
-SQ_CHECK_DECOMPRESS([LZ4],[lz4],[LZ4_decompress_safe],[lz4.h],,[lz4])
-SQ_CHECK_DECOMPRESS([ZSTD],[zstd],[ZSTD_decompress],[zstd.h],,[zstd])
+SQ_CHECK_DECOMPRESS([LZO],[lzo2],[lzo1x_decompress_safe],[lzo/lzo1x.h],[lzo2],[lzo])
+SQ_CHECK_DECOMPRESS([LZ4],[lz4],[LZ4_decompress_safe],[lz4.h],[liblz4],[lz4])
+SQ_CHECK_DECOMPRESS([ZSTD],[zstd],[ZSTD_decompress],[zstd.h],[libzstd],[zstd])
 AS_IF([test "x$sq_decompressors" = x],
 	[AC_MSG_FAILURE([At least one decompression library must exist])])
 
@@ -124,6 +124,7 @@ AS_IF([test x$broken_dir_offsets = xyes],
 	[AC_DEFINE(SQFS_BROKEN_DIR_OFFSETS, 1, [Handle broken directory offsets])])
 
 AC_SUBST([sq_decompressors])
+AC_SUBST([sq_decompressors_pkgconf])
 AC_SUBST([sq_high_level])
 AC_SUBST([sq_low_level])
 AC_SUBST([sq_demo])

--- a/m4/squashfuse_decompress.m4
+++ b/m4/squashfuse_decompress.m4
@@ -1,6 +1,6 @@
 # Copyright (c) 2012 Dave Vasilevsky <dave@vasilevsky.ca>
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
 # are met:
@@ -9,7 +9,7 @@
 # 2. Redistributions in binary form must reproduce the above copyright
 #    notice, this list of conditions and the following disclaimer in the
 #    documentation and/or other materials provided with the distribution.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
 # IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
 # OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
@@ -29,7 +29,7 @@
 # On success modify CPPFLAGS and LIBS and append NAME to sq_decompressors.
 AC_DEFUN([SQ_CHECK_DECOMPRESS],[
 	SQ_SAVE_FLAGS
-	
+
 	sq_want=yes
 	sq_specified=no
 	AC_ARG_WITH(m4_tolower($1),
@@ -43,21 +43,22 @@ AC_DEFUN([SQ_CHECK_DECOMPRESS],[
 			LIBS="$LIBS -L$withval/lib"
 		])
 	])
-	
+
 	sq_dec_ok=
-	AS_IF([test "x$sq_want" = xyes],[		
+	AS_IF([test "x$sq_want" = xyes],[
 		sq_lib="$2"
 		m4_ifval($5,[AS_IF([test "x$sq_specified" = xno],[
 			SQ_PKG($1,$5,[sq_lib=],[:])
 		])])
-		
+
 		sq_dec_ok=yes
 		AC_SEARCH_LIBS($3,[$sq_lib],,[sq_dec_ok=])
 		AS_IF([test "x$sq_dec_ok" = xyes],[AC_CHECK_HEADERS($4,,[sq_dec_ok=])])
-		
+
 		AS_IF([test "x$sq_dec_ok" = xyes],[
 			sq_decompressors="$sq_decompressors $1"
 			sq_mksquashfs_compressors="$sq_mksquashfs_compressors $6"
+			sq_decompressors_pkgconf="$sq_decompressors_pkgconf $5"
 		],[
 			AS_IF([test "x$sq_specified" = xyes],
 				[AC_MSG_FAILURE([Asked for ]$1[, but it can't be found])])

--- a/squashfuse.pc.in
+++ b/squashfuse.pc.in
@@ -8,5 +8,6 @@ Description: squashfuse library to mount squashfs archives
 Version: @VERSION@
 
 Requires:
+Requires.private: @sq_decompressors_pkgconf@
 Libs: -L${libdir} -lsquashfuse
 Cflags: -I${includedir}

--- a/squashfuse_ll.pc.in
+++ b/squashfuse_ll.pc.in
@@ -7,6 +7,7 @@ Name: squashfuse_ll
 Description: squashfuse low-level library to mount squashfs archives
 Version: @VERSION@
 
-Requires:
-Libs: -L${libdir} -lsquashfuse -lsquashfuse_ll
+Requires: squashfuse
+Requires.private: fuse
+Libs: -L${libdir} -lsquashfuse_ll
 Cflags: -I${includedir}


### PR DESCRIPTION
This ensures that `pkg-config --static squashfuse` includes all private dependencies, which is required for static linking.